### PR TITLE
[Feat] PostgreSQL 연동 및 JPA 연결 테스트 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,46 @@
+plugins {
+	id 'java'
+	id 'org.springframework.boot' version '3.5.9'
+	id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.proovy'
+version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
+
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(21)
+	}
+}
+
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+}
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'org.postgresql:postgresql'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+	useJUnitPlatform()
+}

--- a/src/main/java/com/proovy/ProovyApiApplication.java
+++ b/src/main/java/com/proovy/ProovyApiApplication.java
@@ -1,0 +1,13 @@
+package com.proovy;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ProovyApiApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(ProovyApiApplication.class, args);
+	}
+
+}

--- a/src/main/java/com/proovy/domain/test/TestController.java
+++ b/src/main/java/com/proovy/domain/test/TestController.java
@@ -1,0 +1,24 @@
+package com.proovy.domain.test;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/test")
+@RequiredArgsConstructor
+public class TestController {
+
+    private final TestRepository testRepository;
+
+    @PostMapping
+    public TestEntity create(@RequestParam String message) {
+        return testRepository.save(new TestEntity(message));
+    }
+
+    @GetMapping
+    public List<TestEntity> findAll() {
+        return testRepository.findAll();
+    }
+}

--- a/src/main/java/com/proovy/domain/test/TestEntity.java
+++ b/src/main/java/com/proovy/domain/test/TestEntity.java
@@ -1,0 +1,23 @@
+package com.proovy.domain.test;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "connection_test")
+@Getter
+@NoArgsConstructor
+public class TestEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String message;
+
+    public TestEntity(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/proovy/domain/test/TestRepository.java
+++ b/src/main/java/com/proovy/domain/test/TestRepository.java
@@ -1,0 +1,6 @@
+package com.proovy.domain.test;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TestRepository extends JpaRepository<TestEntity, Long> {
+}


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #1 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 📝 문서 수정 (docs)
- [ ] 🔧 설정 변경 (chore)

## 📝 작업 내용

- PostgreSQL datasource 설정 (local profile)
- JPA 기반 테스트용 Entity 및 Repository 구현
- TestController를 통한 DB CRUD 테스트 API 추가
- HikariCP 연결 설정 및 정상 동작 확인

## 📸 스크린샷

<img width="496" height="491" alt="533152070-8b374495-0337-4e42-904f-e7f9c1b8d5e0" src="https://github.com/user-attachments/assets/9cd35f10-9d24-41b6-a015-3184180c46ba" />

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 로컬 환경에서 정상 실행을 확인했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 테스트용 Entity 및 Test API는 추후 실제 도메인 구현 시 제거 예정
- prod 환경 적용 전 `spring.jpa.hibernate.ddl-auto` 설정 변경 필요
