### PR TITLE
[Feat] 전체 저장소 사용량 및 노트별 현황 조회 API

### DIFF
--- a/src/main/java/com/proovy/domain/asset/entity/FileCategory.java
+++ b/src/main/java/com/proovy/domain/asset/entity/FileCategory.java
@@ -43,11 +43,11 @@ public enum FileCategory {
     }
 
     private static boolean isCodeMimeType(String mimeType) {
+        // text/x- 접두사가 text/x-java, text/x-python 등을 커버함
         return mimeType.startsWith("text/x-") ||
-               mimeType.contains("javascript") ||
-               mimeType.contains("typescript") ||
-               mimeType.contains("java") ||
-               mimeType.contains("python") ||
+               mimeType.equals("application/javascript") ||
+               mimeType.equals("text/javascript") ||
+               mimeType.equals("application/typescript") ||
                mimeType.equals("application/json") ||
                mimeType.equals("text/plain") ||
                mimeType.equals("text/html") ||

--- a/src/main/java/com/proovy/domain/asset/entity/FileCategory.java
+++ b/src/main/java/com/proovy/domain/asset/entity/FileCategory.java
@@ -1,0 +1,64 @@
+package com.proovy.domain.asset.entity;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FileCategory {
+    IMAGE("image"),
+    DOCUMENT("document"),
+    CODE("code"),
+    OTHER("other");
+
+    private final String value;
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    public static FileCategory fromMimeType(String mimeType) {
+        if (mimeType == null) {
+            return OTHER;
+        }
+
+        // 이미지 파일
+        if (mimeType.startsWith("image/")) {
+            return IMAGE;
+        }
+
+        // 문서 파일 (PDF)
+        if (mimeType.equals("application/pdf")) {
+            return DOCUMENT;
+        }
+
+        // 코드 파일
+        if (isCodeMimeType(mimeType)) {
+            return CODE;
+        }
+
+        return OTHER;
+    }
+
+    private static boolean isCodeMimeType(String mimeType) {
+        return mimeType.startsWith("text/x-") ||
+               mimeType.contains("javascript") ||
+               mimeType.contains("typescript") ||
+               mimeType.contains("java") ||
+               mimeType.contains("python") ||
+               mimeType.equals("application/json") ||
+               mimeType.equals("text/plain") ||
+               mimeType.equals("text/html") ||
+               mimeType.equals("text/css");
+    }
+
+    /**
+     * 썸네일 제공 여부
+     * image, document 카테고리만 썸네일 제공
+     */
+    public boolean hasThumbnail() {
+        return this == IMAGE || this == DOCUMENT;
+    }
+}

--- a/src/main/java/com/proovy/domain/note/entity/Note.java
+++ b/src/main/java/com/proovy/domain/note/entity/Note.java
@@ -1,0 +1,52 @@
+package com.proovy.domain.note.entity;
+
+import com.proovy.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Note {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "note_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "content_md", columnDefinition = "TEXT")
+    private String contentMd;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Note(User user, String title, String contentMd) {
+        this.user = user;
+        this.title = title;
+        this.contentMd = contentMd;
+    }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+}

--- a/src/main/java/com/proovy/domain/note/repository/NoteRepository.java
+++ b/src/main/java/com/proovy/domain/note/repository/NoteRepository.java
@@ -1,0 +1,18 @@
+package com.proovy.domain.note.repository;
+
+import com.proovy.domain.note.entity.Note;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface NoteRepository extends JpaRepository<Note, Long> {
+
+    List<Note> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    @Query("SELECT n FROM Note n WHERE n.user.id = :userId " +
+           "AND LOWER(n.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+           "ORDER BY n.createdAt DESC")
+    List<Note> searchByTitleKeyword(@Param("userId") Long userId, @Param("keyword") String keyword);
+}

--- a/src/main/java/com/proovy/domain/storage/dto/response/AssetSummaryDto.java
+++ b/src/main/java/com/proovy/domain/storage/dto/response/AssetSummaryDto.java
@@ -15,13 +15,16 @@ public record AssetSummaryDto(
 ) {
     public static AssetSummaryDto from(Asset asset, String thumbnailUrl) {
         FileCategory category = FileCategory.fromMimeType(asset.getMimeType());
+        String source = asset.getSource() != null
+                ? asset.getSource().name().toLowerCase()
+                : "upload";
 
         return AssetSummaryDto.builder()
                 .assetId(asset.getId())
                 .fileName(asset.getFileName())
                 .mimeType(asset.getMimeType())
                 .fileCategory(category.getValue())
-                .source(asset.getSource().name().toLowerCase())
+                .source(source)
                 .thumbnailUrl(category.hasThumbnail() ? thumbnailUrl : null)
                 .build();
     }

--- a/src/main/java/com/proovy/domain/storage/dto/response/AssetSummaryDto.java
+++ b/src/main/java/com/proovy/domain/storage/dto/response/AssetSummaryDto.java
@@ -1,0 +1,28 @@
+package com.proovy.domain.storage.dto.response;
+
+import com.proovy.domain.asset.entity.Asset;
+import com.proovy.domain.asset.entity.FileCategory;
+import lombok.Builder;
+
+@Builder
+public record AssetSummaryDto(
+        Long assetId,
+        String fileName,
+        String mimeType,
+        String fileCategory,
+        String source,
+        String thumbnailUrl
+) {
+    public static AssetSummaryDto from(Asset asset, String thumbnailUrl) {
+        FileCategory category = FileCategory.fromMimeType(asset.getMimeType());
+
+        return AssetSummaryDto.builder()
+                .assetId(asset.getId())
+                .fileName(asset.getFileName())
+                .mimeType(asset.getMimeType())
+                .fileCategory(category.getValue())
+                .source(asset.getSource().name().toLowerCase())
+                .thumbnailUrl(category.hasThumbnail() ? thumbnailUrl : null)
+                .build();
+    }
+}

--- a/src/main/java/com/proovy/domain/storage/dto/response/NoteStorageDto.java
+++ b/src/main/java/com/proovy/domain/storage/dto/response/NoteStorageDto.java
@@ -1,0 +1,46 @@
+package com.proovy.domain.storage.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record NoteStorageDto(
+        Long noteId,
+        String title,
+        Integer storageUsed,
+        Integer storageLimit,
+        String storageUsedDisplay,
+        String storageLimitDisplay,
+        List<AssetSummaryDto> assets
+) {
+    private static final int DEFAULT_NOTE_STORAGE_LIMIT_MB = 500;
+
+    public static NoteStorageDto of(
+            Long noteId,
+            String title,
+            int storageUsedMb,
+            List<AssetSummaryDto> assets
+    ) {
+        return NoteStorageDto.builder()
+                .noteId(noteId)
+                .title(title)
+                .storageUsed(storageUsedMb)
+                .storageLimit(DEFAULT_NOTE_STORAGE_LIMIT_MB)
+                .storageUsedDisplay(formatStorage(storageUsedMb))
+                .storageLimitDisplay(formatStorage(DEFAULT_NOTE_STORAGE_LIMIT_MB))
+                .assets(assets)
+                .build();
+    }
+
+    private static String formatStorage(int mb) {
+        if (mb >= 1000) {
+            double gb = mb / 1000.0;
+            if (gb == Math.floor(gb)) {
+                return String.format("%.0fGB", gb);
+            }
+            return String.format("%.2fGB", gb);
+        }
+        return mb + "MB";
+    }
+}

--- a/src/main/java/com/proovy/domain/storage/dto/response/PlanDto.java
+++ b/src/main/java/com/proovy/domain/storage/dto/response/PlanDto.java
@@ -1,0 +1,7 @@
+package com.proovy.domain.storage.dto.response;
+
+public record PlanDto(
+        String planType,
+        Boolean isActive
+) {
+}

--- a/src/main/java/com/proovy/domain/storage/dto/response/StorageResponse.java
+++ b/src/main/java/com/proovy/domain/storage/dto/response/StorageResponse.java
@@ -1,0 +1,49 @@
+package com.proovy.domain.storage.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record StorageResponse(
+        Integer totalUsed,
+        Integer totalLimit,
+        String totalUsedDisplay,
+        String totalLimitDisplay,
+        Integer usagePercent,
+        PlanDto plan,
+        List<NoteStorageDto> notes
+) {
+    public static StorageResponse of(
+            int totalUsedMb,
+            int totalLimitMb,
+            String planType,
+            boolean isActive,
+            List<NoteStorageDto> notes
+    ) {
+        int usagePercent = totalLimitMb > 0
+                ? Math.round((float) totalUsedMb / totalLimitMb * 100)
+                : 0;
+
+        return StorageResponse.builder()
+                .totalUsed(totalUsedMb)
+                .totalLimit(totalLimitMb)
+                .totalUsedDisplay(formatStorage(totalUsedMb))
+                .totalLimitDisplay(formatStorage(totalLimitMb))
+                .usagePercent(usagePercent)
+                .plan(new PlanDto(planType, isActive))
+                .notes(notes)
+                .build();
+    }
+
+    private static String formatStorage(int mb) {
+        if (mb >= 1000) {
+            double gb = mb / 1000.0;
+            if (gb == Math.floor(gb)) {
+                return String.format("%.0fGB", gb);
+            }
+            return String.format("%.2fGB", gb);
+        }
+        return mb + "MB";
+    }
+}

--- a/src/main/java/com/proovy/domain/storage/service/StorageService.java
+++ b/src/main/java/com/proovy/domain/storage/service/StorageService.java
@@ -1,0 +1,187 @@
+package com.proovy.domain.storage.service;
+
+import com.proovy.domain.asset.entity.Asset;
+import com.proovy.domain.asset.repository.AssetRepository;
+import com.proovy.domain.note.entity.Note;
+import com.proovy.domain.note.repository.NoteRepository;
+import com.proovy.domain.storage.dto.request.BulkDeleteRequest;
+import com.proovy.domain.storage.dto.response.*;
+import com.proovy.domain.user.entity.PlanType;
+import com.proovy.domain.user.entity.User;
+import com.proovy.domain.user.repository.UserPlanRepository;
+import com.proovy.domain.user.repository.UserRepository;
+import com.proovy.global.exception.BusinessException;
+import com.proovy.global.infra.s3.S3Service;
+import com.proovy.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StorageService {
+
+    private final AssetRepository assetRepository;
+    private final UserRepository userRepository;
+    private final NoteRepository noteRepository;
+    private final UserPlanRepository userPlanRepository;
+    private final S3Service s3Service;
+
+    /**
+     * 자산 일괄 삭제
+     * TODO: JWT 인증 구현 후 @AuthenticationPrincipal로 userId 추출
+     *
+     * @param userId 사용자 ID (현재는 파라미터로 전달, 추후 JWT에서 추출)
+     * @param request 삭제할 자산 ID 목록
+     * @return 삭제된 자산 정보
+     */
+    @Transactional
+    public BulkDeleteResponse bulkDeleteAssets(Long userId, BulkDeleteRequest request) {
+        List<Long> assetIds = request.assetIds();
+
+        // 자산 존재 여부 확인
+        List<Asset> assets = assetRepository.findAllByIdIn(assetIds);
+        if (assets.size() != assetIds.size()) {
+            throw new BusinessException(ErrorCode.STORAGE4001);
+        }
+
+        // 권한 검증 (본인 소유 자산만 삭제 가능)
+        long ownedCount = assetRepository.countByIdInAndUserId(assetIds, userId);
+        if (ownedCount != assetIds.size()) {
+            throw new BusinessException(ErrorCode.STORAGE4031);
+        }
+
+        // S3 키 수집 (원본 + 썸네일)
+        List<String> s3KeysToDelete = new ArrayList<>();
+        long totalFileSize = 0L;
+
+        for (Asset asset : assets) {
+            // 원본 파일
+            s3KeysToDelete.add(asset.getS3Key());
+            totalFileSize += asset.getFileSize();
+
+            // 썸네일 파일
+            if (asset.getThumbnailS3Key() != null) {
+                s3KeysToDelete.add(asset.getThumbnailS3Key());
+            }
+        }
+
+        // DB에서 자산 삭제
+        assetRepository.deleteAllInBatch(assets);
+
+        // S3에서 파일 삭제
+        s3Service.deleteFiles(s3KeysToDelete);
+
+        // 스토리지 용량 반환 로깅
+        log.info("[Storage] 사용자 {} - {} 개 파일 삭제, 용량 반환: {} bytes",
+                userId, assets.size(), totalFileSize);
+
+        return BulkDeleteResponse.of(assetIds);
+    }
+
+    /**
+     * 전체 저장소 사용량 및 노트별 현황 조회
+     * TODO: JWT 인증 구현 후 @AuthenticationPrincipal로 userId 추출
+     *
+     * @param userId 사용자 ID
+     * @param keyword 검색어 (노트 제목, 파일명 검색) - nullable
+     * @return 스토리지 사용 현황
+     */
+    public StorageResponse getStorageUsage(Long userId, String keyword) {
+        // 사용자 존재 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER4041));
+
+        // 검색어 길이 검증
+        if (keyword != null && !keyword.isBlank() && keyword.length() < 2) {
+            throw new BusinessException(ErrorCode.STORAGE4003);
+        }
+
+        // 사용자 플랜 조회 (없으면 FREE)
+        PlanType planType = userPlanRepository.findActivePlanTypeByUserId(userId)
+                .orElse(PlanType.FREE);
+        int totalLimitMb = planType.getStorageLimitMb();
+
+        // 노트 목록 조회 (검색어 있으면 필터링)
+        List<Note> notes;
+        if (keyword != null && !keyword.isBlank()) {
+            notes = noteRepository.searchByTitleKeyword(userId, keyword);
+        } else {
+            notes = noteRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        }
+
+        // 사용자의 전체 자산 조회
+        List<Asset> allAssets = assetRepository.findAllByUserId(userId);
+
+        // 노트별 자산 그룹핑
+        Map<Long, List<Asset>> assetsByNoteId = allAssets.stream()
+                .collect(Collectors.groupingBy(Asset::getNoteId));
+
+        // 검색어가 있으면 파일명으로도 필터링된 노트 추가
+        if (keyword != null && !keyword.isBlank()) {
+            String lowerKeyword = keyword.toLowerCase();
+            for (Asset asset : allAssets) {
+                if (asset.getFileName() != null &&
+                    asset.getFileName().toLowerCase().contains(lowerKeyword)) {
+                    // 해당 노트가 이미 포함되어 있지 않으면 추가
+                    Long noteId = asset.getNoteId();
+                    boolean alreadyIncluded = notes.stream()
+                            .anyMatch(n -> n.getId().equals(noteId));
+                    if (!alreadyIncluded) {
+                        noteRepository.findById(noteId).ifPresent(notes::add);
+                    }
+                }
+            }
+        }
+
+        // 전체 사용 용량 계산 (bytes -> MB)
+        long totalUsedBytes = allAssets.stream()
+                .mapToLong(a -> a.getFileSize() != null ? a.getFileSize() : 0L)
+                .sum();
+        int totalUsedMb = (int) (totalUsedBytes / (1024 * 1024));
+
+        // 노트별 DTO 생성
+        List<NoteStorageDto> noteDtos = notes.stream()
+                .map(note -> createNoteStorageDto(note, assetsByNoteId.getOrDefault(note.getId(), List.of())))
+                .toList();
+
+        return StorageResponse.of(
+                totalUsedMb,
+                totalLimitMb,
+                planType.getDisplayName(),
+                true, // 현재 활성 플랜
+                noteDtos
+        );
+    }
+
+    private NoteStorageDto createNoteStorageDto(Note note, List<Asset> assets) {
+        // 노트별 사용 용량 계산
+        long noteUsedBytes = assets.stream()
+                .mapToLong(a -> a.getFileSize() != null ? a.getFileSize() : 0L)
+                .sum();
+        int noteUsedMb = (int) (noteUsedBytes / (1024 * 1024));
+
+        // 자산 DTO 생성
+        List<AssetSummaryDto> assetDtos = assets.stream()
+                .map(asset -> AssetSummaryDto.from(
+                        asset,
+                        s3Service.getThumbnailUrl(asset.getThumbnailS3Key())
+                ))
+                .toList();
+
+        return NoteStorageDto.of(
+                note.getId(),
+                note.getTitle(),
+                noteUsedMb,
+                assetDtos
+        );
+    }
+}

--- a/src/main/java/com/proovy/domain/user/entity/PlanType.java
+++ b/src/main/java/com/proovy/domain/user/entity/PlanType.java
@@ -1,0 +1,20 @@
+package com.proovy.domain.user.entity;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PlanType {
+    FREE("free", 3000),        // 3GB = 3000MB
+    PREMIUM("premium", 100000); // 100GB = 100000MB
+
+    private final String displayName;
+    private final int storageLimitMb;
+
+    @JsonValue
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/main/java/com/proovy/domain/user/entity/User.java
+++ b/src/main/java/com/proovy/domain/user/entity/User.java
@@ -1,0 +1,54 @@
+package com.proovy.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(length = 20)
+    private String phone;
+
+    @Column(length = 50)
+    private String name;
+
+    @Column(nullable = false, length = 30)
+    private String nickname;
+
+    @Column(length = 100)
+    private String department;
+
+    @Column(name = "referral_source", length = 20)
+    private String referralSource;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public User(String phone, String name, String nickname, String department, String referralSource) {
+        this.phone = phone;
+        this.name = name;
+        this.nickname = nickname;
+        this.department = department;
+        this.referralSource = referralSource;
+    }
+}

--- a/src/main/java/com/proovy/domain/user/entity/UserPlan.java
+++ b/src/main/java/com/proovy/domain/user/entity/UserPlan.java
@@ -1,0 +1,48 @@
+package com.proovy.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_plans")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserPlan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_plan_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "plan_type", nullable = false, length = 10)
+    private PlanType planType = PlanType.FREE;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @Column(name = "expired_at")
+    private LocalDateTime expiredAt;
+
+    @Column(name = "is_active")
+    private Boolean isActive = true;
+
+    @Builder
+    public UserPlan(User user, PlanType planType, LocalDateTime startedAt, LocalDateTime expiredAt, Boolean isActive) {
+        this.user = user;
+        this.planType = planType != null ? planType : PlanType.FREE;
+        this.startedAt = startedAt;
+        this.expiredAt = expiredAt;
+        this.isActive = isActive != null ? isActive : true;
+    }
+
+    public int getStorageLimitMb() {
+        return planType.getStorageLimitMb();
+    }
+}

--- a/src/main/java/com/proovy/domain/user/repository/UserPlanRepository.java
+++ b/src/main/java/com/proovy/domain/user/repository/UserPlanRepository.java
@@ -1,0 +1,18 @@
+package com.proovy.domain.user.repository;
+
+import com.proovy.domain.user.entity.PlanType;
+import com.proovy.domain.user.entity.UserPlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface UserPlanRepository extends JpaRepository<UserPlan, Long> {
+
+    @Query("SELECT up FROM UserPlan up WHERE up.user.id = :userId AND up.isActive = true ORDER BY up.startedAt DESC LIMIT 1")
+    Optional<UserPlan> findActiveByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT COALESCE(up.planType, 'FREE') FROM UserPlan up WHERE up.user.id = :userId AND up.isActive = true ORDER BY up.startedAt DESC LIMIT 1")
+    Optional<PlanType> findActivePlanTypeByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/proovy/domain/user/repository/UserPlanRepository.java
+++ b/src/main/java/com/proovy/domain/user/repository/UserPlanRepository.java
@@ -13,6 +13,6 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, Long> {
     @Query("SELECT up FROM UserPlan up WHERE up.user.id = :userId AND up.isActive = true ORDER BY up.startedAt DESC LIMIT 1")
     Optional<UserPlan> findActiveByUserId(@Param("userId") Long userId);
 
-    @Query("SELECT COALESCE(up.planType, 'FREE') FROM UserPlan up WHERE up.user.id = :userId AND up.isActive = true ORDER BY up.startedAt DESC LIMIT 1")
+    @Query("SELECT up.planType FROM UserPlan up WHERE up.user.id = :userId AND up.isActive = true ORDER BY up.startedAt DESC LIMIT 1")
     Optional<PlanType> findActivePlanTypeByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/proovy/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/proovy/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.proovy.domain.user.repository;
+
+import com.proovy.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByPhone(String phone);
+}

--- a/src/main/java/com/proovy/global/infra/s3/S3HealthController.java
+++ b/src/main/java/com/proovy/global/infra/s3/S3HealthController.java
@@ -1,0 +1,93 @@
+package com.proovy.global.infra.s3;
+
+import com.proovy.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Tag(name = "S3 Health Check", description = "S3 연결 상태 확인 API (개발용)")
+@Slf4j
+@RestController
+@RequestMapping("/api/health")
+@RequiredArgsConstructor
+public class S3HealthController {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Operation(
+            summary = "S3 연결 테스트",
+            description = "AWS S3 버킷 연결 상태를 확인합니다. 개발 및 테스트 용도로 사용됩니다."
+    )
+    @GetMapping("/s3")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> checkS3Connection() {
+        Map<String, Object> result = new HashMap<>();
+
+        try {
+            // S3 버킷 존재 여부 및 접근 권한 확인
+            HeadBucketRequest headBucketRequest = HeadBucketRequest.builder()
+                    .bucket(bucketName)
+                    .build();
+
+            s3Client.headBucket(headBucketRequest);
+
+            result.put("status", "OK");
+            result.put("bucketName", bucketName);
+            result.put("message", "S3 버킷에 정상적으로 연결되었습니다.");
+            result.put("accessible", true);
+
+            log.info("[S3 Health Check] 성공 - Bucket: {}", bucketName);
+
+            return ResponseEntity.ok(
+                    ApiResponse.success("S3 연결 테스트 성공", result)
+            );
+
+        } catch (S3Exception e) {
+            result.put("status", "ERROR");
+            result.put("bucketName", bucketName);
+            result.put("accessible", false);
+
+            if (e.awsErrorDetails() != null) {
+                result.put("errorCode", e.awsErrorDetails().errorCode());
+                result.put("errorMessage", e.awsErrorDetails().errorMessage());
+            } else {
+                result.put("errorMessage", e.getMessage());
+            }
+
+            log.error("[S3 Health Check] 실패 - Bucket: {}, Error: {}",
+                    bucketName, e.awsErrorDetails() != null ? e.awsErrorDetails().errorMessage() : e.getMessage());
+
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(
+                    ApiResponse.success("S3 연결 테스트 실패", result)
+            );
+
+        } catch (Exception e) {
+            result.put("status", "ERROR");
+            result.put("bucketName", bucketName);
+            result.put("accessible", false);
+            result.put("errorMessage", e.getMessage());
+
+            log.error("[S3 Health Check] 예외 발생 - Bucket: {}, Error: {}",
+                    bucketName, e.getMessage());
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    ApiResponse.success("S3 연결 테스트 중 오류 발생", result)
+            );
+        }
+    }
+}

--- a/src/main/java/com/proovy/global/infra/s3/S3Service.java
+++ b/src/main/java/com/proovy/global/infra/s3/S3Service.java
@@ -1,0 +1,35 @@
+package com.proovy.global.infra.s3;
+
+import java.util.List;
+
+/**
+ * S3 파일 관리 서비스
+ */
+public interface S3Service {
+
+    /**
+     * S3에서 파일 삭제
+     * @param s3Key S3 저장 경로
+     */
+    void deleteFile(String s3Key);
+
+    /**
+     * S3에서 여러 파일 일괄 삭제
+     * @param s3Keys S3 저장 경로 목록
+     */
+    void deleteFiles(List<String> s3Keys);
+
+    /**
+     * S3 파일의 공개 URL 반환
+     * @param s3Key S3 저장 경로
+     * @return 공개 URL
+     */
+    String getFileUrl(String s3Key);
+
+    /**
+     * 썸네일 URL 반환 (썸네일 S3 키가 있는 경우)
+     * @param thumbnailS3Key 썸네일 S3 키
+     * @return 썸네일 URL 또는 null
+     */
+    String getThumbnailUrl(String thumbnailS3Key);
+}

--- a/src/main/java/com/proovy/global/infra/s3/S3ServiceImpl.java
+++ b/src/main/java/com/proovy/global/infra/s3/S3ServiceImpl.java
@@ -1,0 +1,187 @@
+package com.proovy.global.infra.s3;
+
+import com.proovy.global.exception.BusinessException;
+import com.proovy.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.io.InputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3ServiceImpl implements S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Override
+    public void deleteFile(String s3Key) {
+        if (s3Key == null || s3Key.isBlank()) return;
+
+        try {
+            DeleteObjectRequest request = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .build();
+
+            s3Client.deleteObject(request);
+            log.info("[S3] 파일 삭제 성공: {}", s3Key);
+
+        } catch (S3Exception e) {
+            log.error("[S3] 파일 삭제 실패: {}, code={}, message={}",
+                    s3Key,
+                    e.awsErrorDetails() != null ? e.awsErrorDetails().errorCode() : "unknown",
+                    e.getMessage(),
+                    e
+            );
+            throw new BusinessException(ErrorCode.COMMON500);
+        }
+    }
+
+    @Override
+    public void deleteFiles(List<String> s3Keys) {
+        if (s3Keys == null || s3Keys.isEmpty()) {
+            log.warn("[S3] 삭제할 파일 목록이 비어있습니다.");
+            return;
+        }
+
+        // S3 DeleteObjects는 최대 1000개까지 지원
+        List<ObjectIdentifier> objectIdentifiers = s3Keys.stream()
+                .filter(key -> key != null && !key.isBlank())
+                .distinct()
+                .map(key -> ObjectIdentifier.builder().key(key).build())
+                .collect(Collectors.toList());
+
+        if (objectIdentifiers.isEmpty()) {
+            log.warn("[S3] 유효한 삭제 대상 key가 없습니다.");
+            return;
+        }
+
+        try {
+            Delete delete = Delete.builder()
+                    .objects(objectIdentifiers)
+                    .build();
+
+            DeleteObjectsRequest request = DeleteObjectsRequest.builder()
+                    .bucket(bucketName)
+                    .delete(delete)
+                    .build();
+
+            DeleteObjectsResponse response = s3Client.deleteObjects(request);
+
+            if (response.hasDeleted()) {
+                log.info("[S3] 파일 일괄 삭제 성공: {} 개", response.deleted().size());
+            }
+
+            // 부분 실패 가능 -> errors 있으면 에러 처리
+            if (response.hasErrors() && !response.errors().isEmpty()) {
+                response.errors().forEach(error ->
+                        log.error("[S3] 파일 삭제 실패 - Key: {}, Code: {}, Message: {}",
+                                error.key(), error.code(), error.message())
+                );
+                throw new BusinessException(ErrorCode.COMMON500);
+            }
+
+        } catch (S3Exception e) {
+            log.error("[S3] 파일 일괄 삭제 실패: {}", e.getMessage(), e);
+            throw new BusinessException(ErrorCode.COMMON500);
+        }
+    }
+
+    /**
+     * 파일 업로드
+     */
+    public String uploadFile(String s3Key, InputStream inputStream, long contentLength, String contentType) {
+        if (s3Key == null || s3Key.isBlank()) {
+            throw new BusinessException(ErrorCode.COMMON400);
+        }
+
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .contentType(contentType)
+                    .contentLength(contentLength)
+                    .build();
+
+            s3Client.putObject(request, RequestBody.fromInputStream(inputStream, contentLength));
+            log.info("[S3] 파일 업로드 성공: {}", s3Key);
+
+            return getFileUrl(s3Key);
+
+        } catch (S3Exception e) {
+            log.error("[S3] 파일 업로드 실패: {}, code={}, message={}",
+                    s3Key,
+                    e.awsErrorDetails() != null ? e.awsErrorDetails().errorCode() : "unknown",
+                    e.getMessage(),
+                    e
+            );
+            throw new BusinessException(ErrorCode.COMMON500);
+        }
+    }
+
+    /**
+     * 파일 URL 생성
+     */
+    @Override
+    public String getFileUrl(String s3Key) {
+        if (s3Key == null || s3Key.isBlank()) {
+            return null;
+        }
+        String encodedKey = URLEncoder.encode(s3Key, StandardCharsets.UTF_8)
+                .replace("+", "%20");
+        return String.format("https://%s.s3.%s.amazonaws.com/%s",
+                bucketName,
+                region,
+                encodedKey);
+    }
+
+    /**
+     * 썸네일 URL 반환
+     */
+    @Override
+    public String getThumbnailUrl(String thumbnailS3Key) {
+        if (thumbnailS3Key == null || thumbnailS3Key.isBlank()) {
+            return null;
+        }
+        return getFileUrl(thumbnailS3Key);
+    }
+
+    /**
+     * 파일 존재 여부 확인
+     */
+    public boolean doesFileExist(String s3Key) {
+        if (s3Key == null || s3Key.isBlank()) return false;
+
+        try {
+            HeadObjectRequest request = HeadObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .build();
+
+            s3Client.headObject(request);
+            return true;
+
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) return false;
+
+            log.error("[S3] 파일 존재 확인 실패: {}", e.getMessage(), e);
+            throw new BusinessException(ErrorCode.COMMON500);
+        }
+    }
+}

--- a/src/test/java/com/proovy/domain/asset/entity/FileCategoryTest.java
+++ b/src/test/java/com/proovy/domain/asset/entity/FileCategoryTest.java
@@ -1,0 +1,84 @@
+package com.proovy.domain.asset.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.*;
+
+class FileCategoryTest {
+
+    @Test
+    @DisplayName("이미지 MIME 타입은 IMAGE 카테고리로 분류된다")
+    void imageCategory() {
+        assertThat(FileCategory.fromMimeType("image/png")).isEqualTo(FileCategory.IMAGE);
+        assertThat(FileCategory.fromMimeType("image/jpeg")).isEqualTo(FileCategory.IMAGE);
+        assertThat(FileCategory.fromMimeType("image/gif")).isEqualTo(FileCategory.IMAGE);
+        assertThat(FileCategory.fromMimeType("image/webp")).isEqualTo(FileCategory.IMAGE);
+    }
+
+    @Test
+    @DisplayName("PDF MIME 타입은 DOCUMENT 카테고리로 분류된다")
+    void documentCategory() {
+        assertThat(FileCategory.fromMimeType("application/pdf")).isEqualTo(FileCategory.DOCUMENT);
+    }
+
+    @ParameterizedTest
+    @DisplayName("코드 MIME 타입은 CODE 카테고리로 분류된다")
+    @ValueSource(strings = {
+            "text/x-python",
+            "text/x-java",
+            "text/javascript",
+            "application/javascript",
+            "application/json",
+            "text/plain",
+            "text/html",
+            "text/css"
+    })
+    void codeCategory(String mimeType) {
+        assertThat(FileCategory.fromMimeType(mimeType)).isEqualTo(FileCategory.CODE);
+    }
+
+    @ParameterizedTest
+    @DisplayName("알 수 없는 MIME 타입은 OTHER 카테고리로 분류된다")
+    @ValueSource(strings = {
+            "application/zip",
+            "application/octet-stream",
+            "video/mp4",
+            "audio/mpeg"
+    })
+    void otherCategory(String mimeType) {
+        assertThat(FileCategory.fromMimeType(mimeType)).isEqualTo(FileCategory.OTHER);
+    }
+
+    @ParameterizedTest
+    @DisplayName("null MIME 타입은 OTHER 카테고리로 분류된다")
+    @NullSource
+    void nullMimeType(String mimeType) {
+        assertThat(FileCategory.fromMimeType(mimeType)).isEqualTo(FileCategory.OTHER);
+    }
+
+    @ParameterizedTest
+    @DisplayName("IMAGE, DOCUMENT 카테고리만 썸네일을 제공한다")
+    @CsvSource({
+            "IMAGE, true",
+            "DOCUMENT, true",
+            "CODE, false",
+            "OTHER, false"
+    })
+    void hasThumbnail(FileCategory category, boolean expected) {
+        assertThat(category.hasThumbnail()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("JSON 직렬화 시 소문자 값을 반환한다")
+    void jsonValue() {
+        assertThat(FileCategory.IMAGE.getValue()).isEqualTo("image");
+        assertThat(FileCategory.DOCUMENT.getValue()).isEqualTo("document");
+        assertThat(FileCategory.CODE.getValue()).isEqualTo("code");
+        assertThat(FileCategory.OTHER.getValue()).isEqualTo("other");
+    }
+}

--- a/src/test/java/com/proovy/domain/storage/dto/response/StorageResponseTest.java
+++ b/src/test/java/com/proovy/domain/storage/dto/response/StorageResponseTest.java
@@ -1,0 +1,78 @@
+package com.proovy.domain.storage.dto.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+class StorageResponseTest {
+
+    @Test
+    @DisplayName("StorageResponse가 올바르게 생성된다")
+    void createStorageResponse() {
+        // given & when
+        StorageResponse response = StorageResponse.of(
+                430,
+                3000,
+                "free",
+                true,
+                List.of()
+        );
+
+        // then
+        assertThat(response.totalUsed()).isEqualTo(430);
+        assertThat(response.totalLimit()).isEqualTo(3000);
+        assertThat(response.plan().planType()).isEqualTo("free");
+        assertThat(response.plan().isActive()).isTrue();
+        assertThat(response.notes()).isEmpty();
+    }
+
+    @ParameterizedTest
+    @DisplayName("용량이 올바른 형식으로 표시된다")
+    @CsvSource({
+            "0, 3000, 0MB, 3GB",
+            "430, 3000, 430MB, 3GB",
+            "1000, 3000, 1GB, 3GB",
+            "1500, 3000, 1.50GB, 3GB",
+            "2500, 100000, 2.50GB, 100GB"
+    })
+    void formatStorage(int used, int limit, String expectedUsed, String expectedLimit) {
+        // when
+        StorageResponse response = StorageResponse.of(used, limit, "free", true, List.of());
+
+        // then
+        assertThat(response.totalUsedDisplay()).isEqualTo(expectedUsed);
+        assertThat(response.totalLimitDisplay()).isEqualTo(expectedLimit);
+    }
+
+    @ParameterizedTest
+    @DisplayName("사용률이 올바르게 계산된다")
+    @CsvSource({
+            "0, 3000, 0",
+            "300, 3000, 10",
+            "1500, 3000, 50",
+            "2700, 3000, 90",
+            "3000, 3000, 100"
+    })
+    void calculateUsagePercent(int used, int limit, int expectedPercent) {
+        // when
+        StorageResponse response = StorageResponse.of(used, limit, "free", true, List.of());
+
+        // then
+        assertThat(response.usagePercent()).isEqualTo(expectedPercent);
+    }
+
+    @Test
+    @DisplayName("limit이 0이면 usagePercent는 0이다")
+    void zeroLimitReturnsZeroPercent() {
+        // when
+        StorageResponse response = StorageResponse.of(100, 0, "free", true, List.of());
+
+        // then
+        assertThat(response.usagePercent()).isEqualTo(0);
+    }
+}

--- a/src/test/java/com/proovy/domain/storage/service/StorageServiceTest.java
+++ b/src/test/java/com/proovy/domain/storage/service/StorageServiceTest.java
@@ -1,0 +1,247 @@
+package com.proovy.domain.storage.service;
+
+import com.proovy.domain.asset.entity.Asset;
+import com.proovy.domain.asset.repository.AssetRepository;
+import com.proovy.domain.note.entity.Note;
+import com.proovy.domain.note.repository.NoteRepository;
+import com.proovy.domain.storage.dto.response.StorageResponse;
+import com.proovy.domain.user.entity.PlanType;
+import com.proovy.domain.user.entity.User;
+import com.proovy.domain.user.repository.UserPlanRepository;
+import com.proovy.domain.user.repository.UserRepository;
+import com.proovy.global.exception.BusinessException;
+import com.proovy.global.infra.s3.S3Service;
+import com.proovy.global.response.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class StorageServiceTest {
+
+    @InjectMocks
+    private StorageService storageService;
+
+    @Mock
+    private AssetRepository assetRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private NoteRepository noteRepository;
+
+    @Mock
+    private UserPlanRepository userPlanRepository;
+
+    @Mock
+    private S3Service s3Service;
+
+    private User testUser;
+    private Note testNote;
+    private Asset testAsset;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .nickname("테스트유저")
+                .build();
+
+        testNote = Note.builder()
+                .user(testUser)
+                .title("테스트 노트")
+                .build();
+
+        testAsset = Asset.builder()
+                .userId(1L)
+                .noteId(1L)
+                .fileName("test.pdf")
+                .fileSize(1024L * 1024L * 100) // 100MB
+                .mimeType("application/pdf")
+                .s3Key("users/1/assets/test.pdf")
+                .source(Asset.AssetSource.upload)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("getStorageUsage 메서드")
+    class GetStorageUsage {
+
+        @Test
+        @DisplayName("성공 - 스토리지 사용량을 정상적으로 조회한다")
+        void success() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+            given(userPlanRepository.findActivePlanTypeByUserId(userId)).willReturn(Optional.of(PlanType.FREE));
+            given(noteRepository.findByUserIdOrderByCreatedAtDesc(userId)).willReturn(List.of(testNote));
+            given(assetRepository.findAllByUserId(userId)).willReturn(List.of(testAsset));
+            given(s3Service.getThumbnailUrl(any())).willReturn(null);
+
+            // when
+            StorageResponse response = storageService.getStorageUsage(userId, null);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.totalLimit()).isEqualTo(3000); // FREE 플랜 3GB
+            assertThat(response.plan().planType()).isEqualTo("free");
+            assertThat(response.plan().isActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공 - 검색어로 노트를 필터링한다")
+        void successWithKeyword() {
+            // given
+            Long userId = 1L;
+            String keyword = "테스트";
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+            given(userPlanRepository.findActivePlanTypeByUserId(userId)).willReturn(Optional.of(PlanType.FREE));
+            given(noteRepository.searchByTitleKeyword(userId, keyword)).willReturn(List.of(testNote));
+            given(assetRepository.findAllByUserId(userId)).willReturn(List.of(testAsset));
+            given(s3Service.getThumbnailUrl(any())).willReturn(null);
+
+            // when
+            StorageResponse response = storageService.getStorageUsage(userId, keyword);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.notes()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("실패 - 사용자가 존재하지 않으면 예외를 던진다")
+        void failUserNotFound() {
+            // given
+            Long userId = 999L;
+            given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storageService.getStorageUsage(userId, null))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER4041);
+        }
+
+        @Test
+        @DisplayName("실패 - 검색어가 2자 미만이면 예외를 던진다")
+        void failKeywordTooShort() {
+            // given
+            Long userId = 1L;
+            String keyword = "테"; // 1자
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when & then
+            assertThatThrownBy(() -> storageService.getStorageUsage(userId, keyword))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.STORAGE4003);
+        }
+
+        @Test
+        @DisplayName("성공 - 프리미엄 플랜은 100GB 제한이다")
+        void successPremiumPlan() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+            given(userPlanRepository.findActivePlanTypeByUserId(userId)).willReturn(Optional.of(PlanType.PREMIUM));
+            given(noteRepository.findByUserIdOrderByCreatedAtDesc(userId)).willReturn(List.of());
+            given(assetRepository.findAllByUserId(userId)).willReturn(List.of());
+
+            // when
+            StorageResponse response = storageService.getStorageUsage(userId, null);
+
+            // then
+            assertThat(response.totalLimit()).isEqualTo(100000); // PREMIUM 플랜 100GB
+            assertThat(response.plan().planType()).isEqualTo("premium");
+        }
+
+        @Test
+        @DisplayName("성공 - 플랜이 없으면 FREE 플랜이 기본값이다")
+        void successDefaultFreePlan() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+            given(userPlanRepository.findActivePlanTypeByUserId(userId)).willReturn(Optional.empty());
+            given(noteRepository.findByUserIdOrderByCreatedAtDesc(userId)).willReturn(List.of());
+            given(assetRepository.findAllByUserId(userId)).willReturn(List.of());
+
+            // when
+            StorageResponse response = storageService.getStorageUsage(userId, null);
+
+            // then
+            assertThat(response.totalLimit()).isEqualTo(3000); // FREE 플랜 3GB
+            assertThat(response.plan().planType()).isEqualTo("free");
+        }
+
+        @Test
+        @DisplayName("성공 - 용량 계산이 올바르게 수행된다")
+        void successStorageCalculation() {
+            // given
+            Long userId = 1L;
+            Asset asset1 = Asset.builder()
+                    .userId(1L)
+                    .noteId(1L)
+                    .fileName("file1.pdf")
+                    .fileSize(1024L * 1024L * 200) // 200MB
+                    .mimeType("application/pdf")
+                    .s3Key("key1")
+                    .source(Asset.AssetSource.upload)
+                    .build();
+
+            Asset asset2 = Asset.builder()
+                    .userId(1L)
+                    .noteId(1L)
+                    .fileName("file2.png")
+                    .fileSize(1024L * 1024L * 50) // 50MB
+                    .mimeType("image/png")
+                    .s3Key("key2")
+                    .source(Asset.AssetSource.upload)
+                    .build();
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+            given(userPlanRepository.findActivePlanTypeByUserId(userId)).willReturn(Optional.of(PlanType.FREE));
+            given(noteRepository.findByUserIdOrderByCreatedAtDesc(userId)).willReturn(List.of(testNote));
+            given(assetRepository.findAllByUserId(userId)).willReturn(List.of(asset1, asset2));
+            given(s3Service.getThumbnailUrl(any())).willReturn(null);
+
+            // when
+            StorageResponse response = storageService.getStorageUsage(userId, null);
+
+            // then
+            assertThat(response.totalUsed()).isEqualTo(250); // 200 + 50 = 250MB
+        }
+
+        @Test
+        @DisplayName("성공 - 노트가 없으면 빈 배열을 반환한다")
+        void successEmptyNotes() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+            given(userPlanRepository.findActivePlanTypeByUserId(userId)).willReturn(Optional.of(PlanType.FREE));
+            given(noteRepository.findByUserIdOrderByCreatedAtDesc(userId)).willReturn(List.of());
+            given(assetRepository.findAllByUserId(userId)).willReturn(List.of());
+
+            // when
+            StorageResponse response = storageService.getStorageUsage(userId, null);
+
+            // then
+            assertThat(response.notes()).isEmpty();
+            assertThat(response.totalUsed()).isEqualTo(0);
+        }
+    }
+}

--- a/src/test/java/com/proovy/domain/storage/service/StorageServiceTest.java
+++ b/src/test/java/com/proovy/domain/storage/service/StorageServiceTest.java
@@ -7,6 +7,7 @@ import com.proovy.domain.note.repository.NoteRepository;
 import com.proovy.domain.storage.dto.response.StorageResponse;
 import com.proovy.domain.user.entity.PlanType;
 import com.proovy.domain.user.entity.User;
+import com.proovy.domain.user.entity.UserPlan;
 import com.proovy.domain.user.repository.UserPlanRepository;
 import com.proovy.domain.user.repository.UserRepository;
 import com.proovy.global.exception.BusinessException;
@@ -55,6 +56,8 @@ class StorageServiceTest {
     private User testUser;
     private Note testNote;
     private Asset testAsset;
+    private UserPlan freePlan;
+    private UserPlan premiumPlan;
 
     @BeforeEach
     void setUp() {
@@ -76,6 +79,18 @@ class StorageServiceTest {
                 .s3Key("users/1/assets/test.pdf")
                 .source(Asset.AssetSource.upload)
                 .build();
+
+        freePlan = UserPlan.builder()
+                .user(testUser)
+                .planType(PlanType.FREE)
+                .isActive(true)
+                .build();
+
+        premiumPlan = UserPlan.builder()
+                .user(testUser)
+                .planType(PlanType.PREMIUM)
+                .isActive(true)
+                .build();
     }
 
     @Nested
@@ -88,7 +103,7 @@ class StorageServiceTest {
             // given
             Long userId = 1L;
             given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
-            given(userPlanRepository.findActivePlanTypeByUserId(userId)).willReturn(Optional.of(PlanType.FREE));
+            given(userPlanRepository.findActiveByUserId(userId)).willReturn(Optional.of(freePlan));
             given(noteRepository.findByUserIdOrderByCreatedAtDesc(userId)).willReturn(List.of(testNote));
             given(assetRepository.findAllByUserId(userId)).willReturn(List.of(testAsset));
             given(s3Service.getThumbnailUrl(any())).willReturn(null);
@@ -110,7 +125,7 @@ class StorageServiceTest {
             Long userId = 1L;
             String keyword = "테스트";
             given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
-            given(userPlanRepository.findActivePlanTypeByUserId(userId)).willReturn(Optional.of(PlanType.FREE));
+            given(userPlanRepository.findActiveByUserId(userId)).willReturn(Optional.of(freePlan));
             given(noteRepository.searchByTitleKeyword(userId, keyword)).willReturn(List.of(testNote));
             given(assetRepository.findAllByUserId(userId)).willReturn(List.of(testAsset));
             given(s3Service.getThumbnailUrl(any())).willReturn(null);
@@ -158,7 +173,7 @@ class StorageServiceTest {
             // given
             Long userId = 1L;
             given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
-            given(userPlanRepository.findActivePlanTypeByUserId(userId)).willReturn(Optional.of(PlanType.PREMIUM));
+            given(userPlanRepository.findActiveByUserId(userId)).willReturn(Optional.of(premiumPlan));
             given(noteRepository.findByUserIdOrderByCreatedAtDesc(userId)).willReturn(List.of());
             given(assetRepository.findAllByUserId(userId)).willReturn(List.of());
 
@@ -176,7 +191,7 @@ class StorageServiceTest {
             // given
             Long userId = 1L;
             given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
-            given(userPlanRepository.findActivePlanTypeByUserId(userId)).willReturn(Optional.empty());
+            given(userPlanRepository.findActiveByUserId(userId)).willReturn(Optional.empty());
             given(noteRepository.findByUserIdOrderByCreatedAtDesc(userId)).willReturn(List.of());
             given(assetRepository.findAllByUserId(userId)).willReturn(List.of());
 
@@ -214,7 +229,7 @@ class StorageServiceTest {
                     .build();
 
             given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
-            given(userPlanRepository.findActivePlanTypeByUserId(userId)).willReturn(Optional.of(PlanType.FREE));
+            given(userPlanRepository.findActiveByUserId(userId)).willReturn(Optional.of(freePlan));
             given(noteRepository.findByUserIdOrderByCreatedAtDesc(userId)).willReturn(List.of(testNote));
             given(assetRepository.findAllByUserId(userId)).willReturn(List.of(asset1, asset2));
             given(s3Service.getThumbnailUrl(any())).willReturn(null);
@@ -232,7 +247,7 @@ class StorageServiceTest {
             // given
             Long userId = 1L;
             given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
-            given(userPlanRepository.findActivePlanTypeByUserId(userId)).willReturn(Optional.of(PlanType.FREE));
+            given(userPlanRepository.findActiveByUserId(userId)).willReturn(Optional.of(freePlan));
             given(noteRepository.findByUserIdOrderByCreatedAtDesc(userId)).willReturn(List.of());
             given(assetRepository.findAllByUserId(userId)).willReturn(List.of());
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #3 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 📝 문서 수정 (docs)
- [ ] 🔧 설정 변경 (chore)

## 📝 작업 내용

- API 엔드포인트 추가
  - `GET /api/storage` - 전체 저장소 사용량 및 노트별 현황 조회 API
  - 노트 제목/파일명으로 검색 가능 (keyword 파라미터, 최소 2자)
- 엔티티 생성
  - `User.java`: 사용자 엔티티 (ERD 기반)
  - `UserPlan.java`: 사용자 플랜 엔티티 (FREE/PREMIUM)
  - `PlanType.java`: 플랜 타입 enum (FREE: 3GB, PREMIUM: 100GB)
  - `Note.java`: 노트 엔티티
  - `FileCategory.java`: 파일 카테고리 enum (image, document, code, other)
- Repository 생성
  - `UserRepository`: 사용자 조회
  - `UserPlanRepository`: 활성 플랜 조회 (`findActivePlanTypeByUserId`)
  - `NoteRepository`: 노트 목록/검색 조회 (`searchByTitleKeyword`)
- 비즈니스 로직 구현 (StorageService)
  - 사용자 존재 여부 검증
  - 검색어 길이 검증 (최소 2자, `STORAGE4003` 예외)
  - 사용자 플랜 조회 (없으면 `FREE` 기본값)
  - 노트별 자산 그룹핑 및 용량 계산 (bytes → MB)
  - 검색어로 노트 제목 + 파일명 동시 검색
  - 썸네일 URL 생성 (image, document 카테고리만)
- DTO 클래스 생성
  - `StorageResponse`: 전체 응답 (용량 계산, Display 변환, 사용률 계산)
  - `NoteStorageDto`: 노트별 정보 (노트당 500MB 제한)
  - `AssetSummaryDto`: 자산 요약 정보 (fileCategory 분류)
  - `PlanDto`: 요금제 정보 (planType, isActive)
- S3 연동 추가
  - `S3Service` 인터페이스에 `getFileUrl()`, `getThumbnailUrl()` 추가
  - `S3ServiceImpl`에서 구현 - 썸네일 URL 생성
  - `S3HealthController` 설정 경로 수정 (`aws.s3.bucket` → `cloud.aws.s3.bucket`)
- 단위 테스트 작성
  - `StorageServiceTest`: 8개 테스트
    - 스토리지 조회 성공
    - 검색어 필터링
    - 사용자 없음 예외
    - 검색어 2자 미만 예외
    - 프리미엄 플랜 100GB 제한
    - 기본 FREE 플랜
    - 용량 계산 검증
    - 빈 노트 배열 반환
  - `FileCategoryTest`: 6개 테스트
    - MIME 타입별 카테고리 분류
    - 썸네일 제공 여부
  - `StorageResponseTest`: 4개 테스트
    - 용량 포맷 변환 (MB/GB)
    - 사용률 계산
- API 문서화 (Swagger)
  - `@operation`: 전체 저장소 조회 상세 설명
  - `@ApiResponses`: 200, 400, 401, 404 응답 문서화
  - `@parameter`: `userId`, `keyword` 파라미터 설명

## 📸 스크린샷

<img width="2124" height="766" alt="535388409-b709a8b2-6685-4bef-8dd2-430ebef08b60" src="https://github.com/user-attachments/assets/200af41b-9b60-4c26-9979-1606b443315b" />

<img width="1223" height="911" alt="535388465-0ce98885-be32-4bef-bea6-24d9dce149de" src="https://github.com/user-attachments/assets/98f0b029-cc4c-4dd0-a197-7f9a872f58b8" />

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

### 추후 개선 사항

- JWT 인증 구현 후 `userId` 파라미터 제거
- 페이지네이션 추가 (노트/자산이 많을 경우)

### 리뷰 시 유의사항

- 현재 JWT 인증이 구현되지 않아 `userId`를 `RequestParam`으로 전달하고 있습니다.  
  추후 Spring Security 및 JWT 인증 구현 시 `@AuthenticationPrincipal`로 변경 예정
- `usagePercent`가 90 이상이고 `planType`이 `free`인 경우 프론트엔드에서 업그레이드 버튼 표시 예정

### API 테스트 방법

- 스토리지 조회  
  `GET /api/storage?userId=1`

- 검색어로 조회  
  `GET /api/storage?userId=1&keyword=이산수학`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 노트 관리 기능 추가 (생성, 수정, 키워드 검색)
  * 저장소 사용량 추적 및 실시간 모니터링
  * 파일 자동 분류 (이미지, 문서, 코드, 기타)
  * 대량 자산 삭제 기능
  * FREE/PREMIUM 사용자 플랜 시스템 (저장소 용량 차등)
  * 저장소 상태 확인 엔드포인트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->