### PR TITLE
[Feat] 네이버 소셜 로그인 구현

### DIFF
--- a/src/main/java/com/proovy/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/proovy/domain/auth/controller/AuthController.java
@@ -43,7 +43,12 @@ public class AuthController {
     ) {
         log.info("카카오 로그인 요청, redirectUri: {}", request.redirectUri());
         LoginResponse response = authService.kakaoLogin(request);
-        return ResponseEntity.ok(ApiResponse.success(response));
+
+        String message = "SIGNUP_REQUIRED".equals(response.loginType())
+                ? "휴대폰 인증이 필요합니다."
+                : "로그인에 성공했습니다.";
+
+        return ResponseEntity.ok(ApiResponse.success(message, response));
     }
 
     @PostMapping("/refresh")
@@ -55,6 +60,6 @@ public class AuthController {
             @Valid @RequestBody TokenRefreshRequest request
     ) {
         TokenDto tokens = authService.refreshToken(request.refreshToken());
-        return ResponseEntity.ok(ApiResponse.success(tokens));
+        return ResponseEntity.ok(ApiResponse.success("토큰이 갱신되었습니다.", tokens));
     }
 }

--- a/src/main/java/com/proovy/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/proovy/domain/auth/controller/AuthController.java
@@ -1,8 +1,10 @@
 package com.proovy.domain.auth.controller;
 
 import com.proovy.domain.auth.dto.request.KakaoLoginRequest;
+import com.proovy.domain.auth.dto.request.NaverLoginRequest;
 import com.proovy.domain.auth.dto.request.TokenRefreshRequest;
 import com.proovy.domain.auth.dto.response.LoginResponse;
+import com.proovy.domain.auth.dto.response.NaverAuthUrlResponse;
 import com.proovy.domain.auth.dto.response.TokenDto;
 import com.proovy.domain.auth.service.AuthService;
 import com.proovy.global.response.ApiResponse;
@@ -13,10 +15,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -51,9 +50,45 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success(message, response));
     }
 
+    @GetMapping("/naver/url")
+    @Operation(
+            operationId = "02_getNaverAuthUrl",
+            summary = "네이버 로그인 URL 생성",
+            description = "네이버 OAuth 인증 URL을 생성합니다. state가 포함되어 있으며, 프론트엔드는 이 URL로 리다이렉트합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "URL 생성 성공")
+    })
+    public ResponseEntity<ApiResponse<NaverAuthUrlResponse>> getNaverAuthUrl() {
+        NaverAuthUrlResponse response = authService.generateNaverAuthUrl();
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/login/naver")
+    @Operation(
+            operationId = "03_naverLogin",
+            summary = "네이버 소셜 로그인",
+            description = "네이버 인가 코드와 state로 로그인합니다. 신규 유저는 회원가입 토큰을 반환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 (AUTH4002, AUTH4011)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류 (AUTH5022)")
+    })
+    public ResponseEntity<ApiResponse<LoginResponse>> naverLogin(
+            @Valid @RequestBody NaverLoginRequest request
+    ) {
+        log.info("네이버 로그인 요청");
+        LoginResponse response = authService.naverLogin(request);
+
+        String message = "SIGNUP_REQUIRED".equals(response.loginType())
+                ? "휴대폰 인증이 필요합니다."
+                : "로그인에 성공했습니다.";
+
+        return ResponseEntity.ok(ApiResponse.success(message, response));
+    }
+
     @PostMapping("/refresh")
     @Operation(
-            operationId = "02_refreshToken",
+            operationId = "04_refreshToken",
             summary = "토큰 갱신",
             description = "Refresh Token으로 새로운 Access Token을 발급합니다.")
     public ResponseEntity<ApiResponse<TokenDto>> refreshToken(

--- a/src/main/java/com/proovy/domain/auth/dto/naver/NaverTokenResponse.java
+++ b/src/main/java/com/proovy/domain/auth/dto/naver/NaverTokenResponse.java
@@ -1,0 +1,14 @@
+package com.proovy.domain.auth.dto.naver;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record NaverTokenResponse(
+        String accessToken,      // 접근 토큰
+        String refreshToken,     // 갱신 토큰
+        String tokenType,        // 토큰 타입 (bearer)
+        Integer expiresIn,       // 유효 기간 (초)
+        String error,            // 에러 코드
+        String errorDescription  // 에러 메시지
+) {}

--- a/src/main/java/com/proovy/domain/auth/dto/naver/NaverUserResponse.java
+++ b/src/main/java/com/proovy/domain/auth/dto/naver/NaverUserResponse.java
@@ -1,0 +1,25 @@
+package com.proovy.domain.auth.dto.naver;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+/**
+ * 네이버 사용자 정보 응답
+ * GET https://openapi.naver.com/v1/nid/me
+ *
+ * 사용하는 필드: id, email, name, mobile
+ * 프로필 이미지는 네이버 기본 로고로 고정
+ */
+public record NaverUserResponse(
+        String resultcode,       // 결과 코드 ("00": 성공)
+        String message,          // 결과 메시지
+        Response response        // 사용자 정보
+) {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record Response(
+            String id,           // 네이버 고유 ID (providerUserId로 저장)
+            String email,        // 이메일
+            String name,         // 이름
+            String mobile        // 휴대폰 번호 (010-1234-5678 형식)
+    ) {}
+}

--- a/src/main/java/com/proovy/domain/auth/dto/request/NaverLoginRequest.java
+++ b/src/main/java/com/proovy/domain/auth/dto/request/NaverLoginRequest.java
@@ -1,0 +1,15 @@
+package com.proovy.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 네이버 로그인 요청
+ * redirectUri는 서버 설정값 사용
+ */
+public record NaverLoginRequest(
+        @NotBlank(message = "인증 코드는 필수입니다")
+        String code,
+
+        @NotBlank(message = "state는 필수입니다")
+        String state
+) {}

--- a/src/main/java/com/proovy/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/proovy/domain/auth/dto/response/LoginResponse.java
@@ -8,7 +8,8 @@ public record LoginResponse(
         UserDto user,              // 기존 유저인 경우 사용자 정보
         TokenDto token,            // 기존 유저인 경우 JWT 토큰
         String signupToken,        // 신규 유저인 경우 회원가입용 임시 토큰
-        KakaoUserInfo kakaoInfo    // 신규 유저인 경우 카카오에서 받은 정보
+        KakaoUserInfo kakaoInfo,   // 신규 유저인 경우 카카오에서 받은 정보
+        NaverUserInfo naverInfo    // 네이버 신규 유저
 ) {
     public static LoginResponse login(UserDto user, TokenDto token) {
         return LoginResponse.builder()
@@ -18,11 +19,21 @@ public record LoginResponse(
                 .build();
     }
 
+    // 카카오 신규 유저
     public static LoginResponse signupRequired(String signupToken, KakaoUserInfo kakaoInfo) {
         return LoginResponse.builder()
                 .loginType("SIGNUP_REQUIRED")
                 .signupToken(signupToken)
                 .kakaoInfo(kakaoInfo)
+                .build();
+    }
+
+    // 네이버 신규 유저
+    public static LoginResponse signupRequired(String signupToken, NaverUserInfo naverInfo) {
+        return LoginResponse.builder()
+                .loginType("SIGNUP_REQUIRED")
+                .signupToken(signupToken)
+                .naverInfo(naverInfo)
                 .build();
     }
 }

--- a/src/main/java/com/proovy/domain/auth/dto/response/NaverAuthUrlResponse.java
+++ b/src/main/java/com/proovy/domain/auth/dto/response/NaverAuthUrlResponse.java
@@ -1,0 +1,13 @@
+package com.proovy.domain.auth.dto.response;
+
+import lombok.Builder;
+
+/**
+ * 네이버 로그인 URL 응답
+ * 프론트엔드는 이 URL로 리다이렉트
+ */
+@Builder
+public record NaverAuthUrlResponse(
+        String authUrl,    // 네이버 로그인 URL (state 포함)
+        String state       // 프론트에서 콜백 시 함께 전달할 state
+) {}

--- a/src/main/java/com/proovy/domain/auth/dto/response/NaverUserInfo.java
+++ b/src/main/java/com/proovy/domain/auth/dto/response/NaverUserInfo.java
@@ -23,11 +23,14 @@ public record NaverUserInfo(
                 .id(user.id())
                 .email(user.email())
                 .name(user.name())
-                .mobile(user.mobile())
+                .mobile(normalizeMobile(user.mobile()))
                 .build();
     }
 
-    // 번호 형식 변경 (010-1234-5678 -> 01012345678)
+    /**
+     * 번호 형식 정규화 (010-1234-5678 -> 01012345678)
+     * 카카오와 동일한 형식으로 맞추기 위해 하이픈 및 특수문자 제거
+     */
     private static String normalizeMobile(String mobile) {
         if (mobile == null) return null;
         return mobile.replaceAll("[^0-9]", "");

--- a/src/main/java/com/proovy/domain/auth/dto/response/NaverUserInfo.java
+++ b/src/main/java/com/proovy/domain/auth/dto/response/NaverUserInfo.java
@@ -19,6 +19,9 @@ public record NaverUserInfo(
 ) {
     public static NaverUserInfo from(NaverUserResponse response) {
         var user = response.response();
+        if (user == null) {
+            throw new IllegalArgumentException("Naver user response is null");
+        }
         return NaverUserInfo.builder()
                 .id(user.id())
                 .email(user.email())

--- a/src/main/java/com/proovy/domain/auth/dto/response/NaverUserInfo.java
+++ b/src/main/java/com/proovy/domain/auth/dto/response/NaverUserInfo.java
@@ -1,0 +1,35 @@
+package com.proovy.domain.auth.dto.response;
+
+import com.proovy.domain.auth.dto.naver.NaverUserResponse;
+import lombok.Builder;
+
+/**
+ * 프론트엔드 전달용 네이버 사용자 정보
+ * 신규 유저 회원가입 시 자동 채움에 사용
+ *
+ * - name: 개인정보 입력 화면에서 이름 자동 채움
+ * - mobile: 휴대폰 인증 화면에서 번호 자동 채움
+ */
+@Builder
+public record NaverUserInfo(
+        String id,      // 네이버 고유 ID
+        String email,   // 이메일
+        String name,    // 이름 (회원가입 시 이름 필드 자동 채움)
+        String mobile   // 휴대폰 번호 (인증 화면에서 자동 채움)
+) {
+    public static NaverUserInfo from(NaverUserResponse response) {
+        var user = response.response();
+        return NaverUserInfo.builder()
+                .id(user.id())
+                .email(user.email())
+                .name(user.name())
+                .mobile(user.mobile())
+                .build();
+    }
+
+    // 번호 형식 변경 (010-1234-5678 -> 01012345678)
+    private static String normalizeMobile(String mobile) {
+        if (mobile == null) return null;
+        return mobile.replaceAll("[^0-9]", "");
+    }
+}

--- a/src/main/java/com/proovy/domain/auth/entity/NaverState.java
+++ b/src/main/java/com/proovy/domain/auth/entity/NaverState.java
@@ -1,0 +1,28 @@
+package com.proovy.domain.auth.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+/**
+ * 네이버 OAuth state 저장용 Redis 엔티티
+ * CSRF 방지를 위해 백엔드에서 생성/검증
+ */
+@Getter
+@RedisHash("naver_state")
+public class NaverState {
+
+    @Id
+    private String state;        // state 값 (UUID)
+
+    @TimeToLive
+    private Long ttl;            // TTL (초)
+
+    @Builder
+    public NaverState(String state, Long ttl) {
+        this.state = state;
+        this.ttl = ttl;
+    }
+}

--- a/src/main/java/com/proovy/domain/auth/provider/NaverOAuthClient.java
+++ b/src/main/java/com/proovy/domain/auth/provider/NaverOAuthClient.java
@@ -78,8 +78,14 @@ public class NaverOAuthClient {
                     .bodyToMono(NaverTokenResponse.class)
                     .block();
 
+            // 응답이 null인 경우 처리
+            if (response == null) {
+                log.error("네이버 토큰 발급 응답이 null입니다");
+                throw new BusinessException(ErrorCode.AUTH5022);
+            }
+
             // 네이버는 200 OK로 에러 반환
-            if (response != null && response.error() != null) {
+            if (response.error() != null) {
                 log.error("네이버 토큰 발급 에러: {} - {}", response.error(), response.errorDescription());
                 throw new BusinessException(ErrorCode.AUTH4011);
             }

--- a/src/main/java/com/proovy/domain/auth/provider/NaverOAuthClient.java
+++ b/src/main/java/com/proovy/domain/auth/provider/NaverOAuthClient.java
@@ -1,0 +1,130 @@
+package com.proovy.domain.auth.provider;
+
+import com.proovy.domain.auth.dto.naver.NaverTokenResponse;
+import com.proovy.domain.auth.dto.naver.NaverUserResponse;
+import com.proovy.global.exception.BusinessException;
+import com.proovy.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NaverOAuthClient {
+
+    private final WebClient webClient;
+
+    @Value("${oauth.naver.client-id}")
+    private String clientId;
+
+    @Value("${oauth.naver.client-secret}")
+    private String clientSecret;
+
+    @Value("${oauth.naver.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${oauth.naver.authorize-uri}")
+    private String authorizeUri;
+
+    @Value("${oauth.naver.token-uri}")
+    private String tokenUri;
+
+    @Value("${oauth.naver.user-info-uri}")
+    private String userInfoUri;
+
+    /**
+     * 네이버 로그인 URL 생성
+     */
+    public String generateAuthUrl(String state) {
+        return authorizeUri +
+                "?response_type=code" +
+                "&client_id=" + clientId +
+                "&redirect_uri=" + redirectUri +
+                "&state=" + state;
+    }
+
+    /**
+     * 인가 코드로 액세스 토큰 발급
+     * redirectUri는 서버 설정값
+     */
+    public NaverTokenResponse getAccessToken(String code, String state) {
+        try {
+            NaverTokenResponse response = webClient.post()
+                    .uri(tokenUri)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData("grant_type", "authorization_code")
+                            .with("client_id", clientId)
+                            .with("client_secret", clientSecret)
+                            .with("redirect_uri", redirectUri)
+                            .with("code", code)
+                            .with("state", state))
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, res ->
+                            res.bodyToMono(String.class)
+                                    .flatMap(body -> {
+                                        log.error("네이버 토큰 발급 실패 (4xx): {}", body);
+                                        return Mono.error(new BusinessException(ErrorCode.AUTH4011));
+                                    }))
+                    .onStatus(HttpStatusCode::is5xxServerError, res ->
+                            Mono.error(new BusinessException(ErrorCode.AUTH5022)))
+                    .bodyToMono(NaverTokenResponse.class)
+                    .block();
+
+            // 네이버는 200 OK로 에러 반환
+            if (response != null && response.error() != null) {
+                log.error("네이버 토큰 발급 에러: {} - {}", response.error(), response.errorDescription());
+                throw new BusinessException(ErrorCode.AUTH4011);
+            }
+
+            return response;
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("네이버 토큰 발급 API 호출 실패", e);
+            throw new BusinessException(ErrorCode.AUTH5022);
+        }
+    }
+
+    /**
+     * 액세스 토큰으로 사용자 정보 조회
+     */
+    public NaverUserResponse getUserInfo(String accessToken) {
+        try {
+            NaverUserResponse response = webClient.get()
+                    .uri(userInfoUri)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, res ->
+                            res.bodyToMono(String.class)
+                                    .flatMap(body -> {
+                                        log.error("네이버 사용자 정보 조회 실패 (4xx): {}", body);
+                                        return Mono.error(new BusinessException(ErrorCode.AUTH4013));
+                                    }))
+                    .onStatus(HttpStatusCode::is5xxServerError, res ->
+                            Mono.error(new BusinessException(ErrorCode.AUTH5022)))
+                    .bodyToMono(NaverUserResponse.class)
+                    .block();
+
+            // 결과 코드 검증
+            if (response == null || !"00".equals(response.resultcode())) {
+                log.error("네이버 사용자 정보 조회 실패: {}", response != null ? response.message() : "null");
+                throw new BusinessException(ErrorCode.AUTH4013);
+            }
+
+            return response;
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("네이버 사용자 정보 조회 API 호출 실패", e);
+            throw new BusinessException(ErrorCode.AUTH5022);
+        }
+    }
+}

--- a/src/main/java/com/proovy/domain/auth/repository/NaverStateRepository.java
+++ b/src/main/java/com/proovy/domain/auth/repository/NaverStateRepository.java
@@ -1,0 +1,7 @@
+package com.proovy.domain.auth.repository;
+
+import com.proovy.domain.auth.entity.NaverState;
+import org.springframework.data.repository.CrudRepository;
+
+public interface NaverStateRepository extends CrudRepository<NaverState, String> {
+}

--- a/src/main/java/com/proovy/domain/auth/service/AuthService.java
+++ b/src/main/java/com/proovy/domain/auth/service/AuthService.java
@@ -124,7 +124,7 @@ public class AuthService {
         String redisKey = "naver_state:" + request.state();
         Boolean deleted = redisTemplate.delete(redisKey);
         if (deleted == null || !deleted) {
-            log.warn("네이버 state 검증 실패 (존재하지 않거나 이미 사용됨): {}", request.state());
+            log.warn("네이버 state 검증 실패 (존재하지 않거나 이미 사용됨)");
             throw new BusinessException(ErrorCode.AUTH4002);
         }
 

--- a/src/main/java/com/proovy/domain/auth/service/AuthService.java
+++ b/src/main/java/com/proovy/domain/auth/service/AuthService.java
@@ -65,7 +65,7 @@ public class AuthService {
         // 3. 네이버 로그인 URL 생성
         String authUrl = naverClient.generateAuthUrl(state);
 
-        log.info("네이버 로그인 URL 생성, state: {}", state);
+        log.info("네이버 로그인 URL 생성");
         return NaverAuthUrlResponse.builder()
                 .authUrl(authUrl)
                 .state(state)

--- a/src/main/java/com/proovy/domain/auth/service/AuthService.java
+++ b/src/main/java/com/proovy/domain/auth/service/AuthService.java
@@ -2,23 +2,32 @@ package com.proovy.domain.auth.service;
 
 import com.proovy.domain.auth.dto.kakao.KakaoTokenResponse;
 import com.proovy.domain.auth.dto.kakao.KakaoUserResponse;
+import com.proovy.domain.auth.dto.naver.NaverTokenResponse;
+import com.proovy.domain.auth.dto.naver.NaverUserResponse;
 import com.proovy.domain.auth.dto.request.KakaoLoginRequest;
+import com.proovy.domain.auth.dto.request.NaverLoginRequest;
 import com.proovy.domain.auth.dto.response.*;
+import com.proovy.domain.auth.entity.NaverState;
 import com.proovy.domain.auth.entity.RefreshToken;
 import com.proovy.domain.auth.provider.KakaoOAuthClient;
+import com.proovy.domain.auth.provider.NaverOAuthClient;
+import com.proovy.domain.auth.repository.NaverStateRepository;
 import com.proovy.domain.auth.repository.RefreshTokenRepository;
 import com.proovy.domain.user.entity.OAuthProvider;
 import com.proovy.domain.user.entity.User;
 import com.proovy.domain.user.repository.UserRepository;
 import com.proovy.global.exception.BusinessException;
 import com.proovy.global.response.ErrorCode;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -27,9 +36,39 @@ import java.util.Optional;
 public class AuthService {
 
     private final KakaoOAuthClient kakaoClient;
+    private final NaverOAuthClient naverClient;
+    private final NaverStateRepository naverStateRepository;
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
+
+    @Value("${oauth.naver.state-ttl:300}")
+    private Long stateTtl;
+
+    /**
+     * 네이버 로그인 URL 생성
+     * state를 생성하고 Redis에 저장 후 authorize URL 반환
+     */
+    public NaverAuthUrlResponse generateNaverAuthUrl() {
+        // 1. state 생성 (UUID)
+        String state = UUID.randomUUID().toString();
+
+        // 2. Redis에 state 저장 (TTL 적용)
+        NaverState naverState = NaverState.builder()
+                .state(state)
+                .ttl(stateTtl)
+                .build();
+        naverStateRepository.save(naverState);
+
+        // 3. 네이버 로그인 URL 생성
+        String authUrl = naverClient.generateAuthUrl(state);
+
+        log.info("네이버 로그인 URL 생성, state: {}", state);
+        return NaverAuthUrlResponse.builder()
+                .authUrl(authUrl)
+                .state(state)
+                .build();
+    }
 
     /**
      * 카카오 로그인 처리
@@ -71,6 +110,54 @@ public class AuthService {
 
             log.info("신규 유저 감지, 회원가입 필요, kakaoId: {}", kakaoUser.id());
             return LoginResponse.signupRequired(signupToken, kakaoInfo);
+        }
+    }
+
+    /**
+     * 네이버 로그인 처리
+     */
+    @Transactional
+    public LoginResponse naverLogin(@Valid NaverLoginRequest request) {
+        // 1. state 검증 (Redis에서 확인 후 삭제)
+        naverStateRepository.findById(request.state())
+                .orElseThrow(() -> {
+                    log.warn("네이버 state 검증 실패: {}", request.state());
+                    return new BusinessException(ErrorCode.AUTH4002);
+                });
+        naverStateRepository.deleteById(request.state());
+
+        // 2. 네이버 액세스 토큰 발급
+        NaverTokenResponse naverToken = naverClient.getAccessToken(
+                request.code(),
+                request.state()
+        );
+        log.info("네이버 토큰 발급 성공, expires_in: {}", naverToken.expiresIn());
+
+        // 3. 네이버 사용자 정보 조회
+        NaverUserResponse naverUser = naverClient.getUserInfo(naverToken.accessToken());
+        log.info("네이버 사용자 정보 조회 성공, id: {}", naverUser.response().id());
+
+        // 4. 기존 유저 조회
+        String providerUserId = naverUser.response().id();
+        Optional<User> existingUser = userRepository
+                .findByProviderAndProviderUserId(OAuthProvider.NAVER, providerUserId);
+
+        // 5. 분기 처리
+        if (existingUser.isPresent()) {
+            // 기존 유저: JWT 발급
+            User user = existingUser.get();
+            TokenDto tokens = jwtTokenProvider.generateTokens(user.getId());
+            saveRefreshToken(user.getId(), tokens.refreshToken());
+
+            log.info("기존 유저 로그인 성공 (네이버), userId: {}", user.getId());
+            return LoginResponse.login(UserDto.from(user), tokens);
+        } else {
+            // 신규 유저: signupToken 발급
+            NaverUserInfo naverInfo = NaverUserInfo.from(naverUser);
+            String signupToken = jwtTokenProvider.generateSignupToken(naverInfo);
+
+            log.info("신규 유저 감지 (네이버), 회원가입 필요, naverId: {}", providerUserId);
+            return LoginResponse.signupRequired(signupToken, naverInfo);
         }
     }
 

--- a/src/main/java/com/proovy/domain/auth/service/JwtTokenProvider.java
+++ b/src/main/java/com/proovy/domain/auth/service/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package com.proovy.domain.auth.service;
 
 import com.proovy.domain.auth.dto.response.KakaoUserInfo;
+import com.proovy.domain.auth.dto.response.NaverUserInfo;
 import com.proovy.domain.auth.dto.response.TokenDto;
 import com.proovy.global.exception.BusinessException;
 import com.proovy.global.response.ErrorCode;
@@ -80,6 +81,26 @@ public class JwtTokenProvider {
                 .claim("type", "signup")
                 .claim("provider", "KAKAO")
                 .claim("email", kakaoInfo.email())
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + signupTokenExpiration))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    /**
+     * 회원가입용 임시 토큰 생성 (네이버 정보 포함)
+     * 네이버는 이름, 휴대폰 번호도 포함
+     */
+    public String generateSignupToken(NaverUserInfo naverInfo) {
+        Date now = new Date();
+
+        return Jwts.builder()
+                .subject(naverInfo.id())
+                .claim("type", "signup")
+                .claim("provider", "NAVER")
+                .claim("email", naverInfo.email())
+                .claim("name", naverInfo.name())
+                .claim("mobile", naverInfo.mobile())
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + signupTokenExpiration))
                 .signWith(secretKey)

--- a/src/main/java/com/proovy/global/response/ErrorCode.java
+++ b/src/main/java/com/proovy/global/response/ErrorCode.java
@@ -15,11 +15,13 @@ public enum ErrorCode {
 
     // Auth
     AUTH4001("AUTH4001", "Redirect URI가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    AUTH4002("AUTH4002", "state 값이 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
     AUTH4011("AUTH4011", "유효하지 않은 인증 코드입니다.", HttpStatus.UNAUTHORIZED),
     AUTH4012("AUTH4012", "토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
     AUTH4013("AUTH4013", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
     AUTH4291("AUTH4291", "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.", HttpStatus.TOO_MANY_REQUESTS),
     AUTH5021("AUTH5021", "카카오 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    AUTH5022("AUTH5022", "네이버 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // User
     USER4041("USER4041", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,7 +43,7 @@ cloud:
       auto: false  # CloudFormation 스택 생성 비활성화
 
 # ===============================
-# 카카오 OAuth 설정
+# OAuth 설정
 # ===============================
 oauth:
   kakao:
@@ -57,6 +57,14 @@ oauth:
     token-uri: https://kauth.kakao.com/oauth/token
     user-info-uri: https://kapi.kakao.com/v2/user/me
     token-info-uri: https://kapi.kakao.com/v1/user/access_token_info
+
+  naver:
+    client-id: ${NAVER_CLIENT_ID}
+    client-secret: ${NAVER_CLIENT_SECRET}
+    redirect-uri: ${NAVER_REDIRECT_URI:http://localhost:3000/oauth/naver/callback}
+    # 네이버 API 엔드포인트
+    token-uri: https://nid.naver.com/oauth2.0/token
+    user-info-uri: https://openapi.naver.com/v1/nid/me
 
 # ===============================
 # JWT 설정 (서비스 자체 토큰)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -61,10 +61,14 @@ oauth:
   naver:
     client-id: ${NAVER_CLIENT_ID}
     client-secret: ${NAVER_CLIENT_SECRET}
+    # redirectUri는 서버에서 고정 (보안상 Request Body에서 받지 않음)
     redirect-uri: ${NAVER_REDIRECT_URI:http://localhost:3000/oauth/naver/callback}
     # 네이버 API 엔드포인트
+    authorize-uri: https://nid.naver.com/oauth2.0/authorize
     token-uri: https://nid.naver.com/oauth2.0/token
     user-info-uri: https://openapi.naver.com/v1/nid/me
+    # state 유효 시간 (초)
+    state-ttl: 300
 
 # ===============================
 # JWT 설정 (서비스 자체 토큰)


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #6 
- Related #8 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 네이버 OAuth 2.0 소셜 로그인 구현
  - **GET** `/api/auth/naver/url` : 네이버 로그인 URL 생성 (state 포함)
  - **POST** `/api/auth/login/naver` : 인가 코드(code) + state 기반 로그인 처리
- 네이버 OAuth 인증 흐름 적용 (카카오와 차이점 반영)
  - **state 파라미터 필수**: CSRF 공격 방지를 위해 백엔드에서 state 생성/검증
  - **redirectUri 서버 고정**: `application.yaml` 설정값 사용 (Request Body에서 제거)
  - 네이버 사용자 정보 응답 구조(`response` 객체 내부 필드)에 맞춰 파싱 처리
- 기존 유저 / 신규 유저 분기 처리
  - 기존 유저: JWT 토큰 발급 및 로그인 응답 (`loginType = LOGIN`)
  - 신규 유저: `signupToken` 발급 및 회원가입 필요 응답 (`loginType = SIGNUP_REQUIRED`)
  - 신규 유저 응답에 `naverInfo` 포함 (이름 / 휴대폰 번호 자동 채움 용도)
- DTO 추가 및 수정
  - `NaverAuthUrlResponse` (authUrl, state)
  - `NaverLoginRequest` (code, state)
  - `NaverTokenResponse` (snake_case 매핑)
  - `NaverUserResponse` (resultcode / message / response 구조)
  - `NaverUserInfo` (프론트 전달용: id, email, name, mobile)
  - `LoginResponse`에 `naverInfo` 필드 추가 (신규 유저 응답용)
- OAuth Provider 확장
  - `OAuthProvider`에 `NAVER` 추가 (네이버 기본 로고 URL 사용)
- Redis 기반 state 저장 및 검증
  - `NaverState` (RedisHash) + `NaverStateRepository` 신규 추가
  - state TTL 적용 및 **검증 후 즉시 삭제**하여 재사용 방지
- 네이버 OAuth API 연동 클라이언트 구현
  - `NaverOAuthClient`에서 토큰 발급 / 사용자 정보 조회 처리
  - 네이버 특이 케이스(200 OK + error 필드 반환) 대응
- 에러 코드 / 예외 처리 추가
  - `AUTH4002`: state 값 불일치 (CSRF 검증 실패)
  - `AUTH5022`: 네이버 서버 오류
- 환경 설정 반영
  - `application.yaml`에 `oauth.naver.*` 설정 추가
  - `.env`에 `NAVER_CLIENT_ID`, `NAVER_CLIENT_SECRET`, `NAVER_REDIRECT_URI` 적용

## 📸 스크린샷

### 1. 신규 유저 (회원가입 필요) 테스트

우선 Swagger에서 네이버 로그인 URL을 생성합니다.
- `GET /api/auth/naver/url` 실행

<img width="719" height="866" alt="스크린샷 2026-01-21 062306" src="https://github.com/user-attachments/assets/518ecb8d-ae76-43ec-8a0e-14c8594e6687" />

authUrl을 접속해서 네이버 로그인 후 동의하기를 클릭해줍니다.

<img width="728" height="705" alt="스크린샷 2026-01-21 061237" src="https://github.com/user-attachments/assets/30d035db-d8f8-4b6b-84cb-d5de5d5ad92b" />

콜백 URL에서 주소창의 Authorization Code를 확인합니다.

<img width="722" height="886" alt="스크린샷 2026-01-21 061254" src="https://github.com/user-attachments/assets/9d2f7cd6-a8fb-44e4-afb1-54e4273bb5ba" />

리다이렉트된 URL 예시) http://localhost:3000/oauth/naver/callback?code=XXXX&state=YYYY

이제 Swagger에서 네이버 소셜 로그인을 호출합니다.

<img width="712" height="738" alt="스크린샷 2026-01-21 062422" src="https://github.com/user-attachments/assets/c39e0e3e-da4b-4b31-bcee-e593c5b4d5c8" />

<img width="925" height="717" alt="스크린샷 2026-01-23 032256" src="https://github.com/user-attachments/assets/d04a490e-a700-4601-904d-e8aec5908417" />

응답으로 휴대폰 인증이 필요하다는 성공 응답이 잘 온 걸 확인할 수 있습니다.
naverInfo (id, email, name, mobile) 확인
naverInfo.id → providerUserId (네이버 계정 고유값)

### 2. 기존 유저 (LOGIN) 테스트

회원가입 완료 API 미구현 상태로, pgAdmin에서 Users 테이블에 provider=NAVER + providerUserId 직접 Insert 후 테스트 했습니다.

<img width="553" height="447" alt="스크린샷 2026-01-21 063754" src="https://github.com/user-attachments/assets/9eca542c-e75f-4bcc-b903-e5ff1a7d9988" />

<img width="876" height="370" alt="스크린샷 2026-01-21 064541" src="https://github.com/user-attachments/assets/5b7f98af-6f71-42e7-badb-f1b5270538ae" />

NAVER 유저 레코드 확인 후 같은 네이버 계정으로 인가 코드를 재발급 받아줍니다. (Authorization Code는 일회용이므로 재발급 필요)

<img width="707" height="812" alt="538348776-65b698c9-c3e3-4841-887c-5481a795a32f" src="https://github.com/user-attachments/assets/11029b0e-eed7-4dd9-a3d1-2c16312cc435" />

Swagger에서 다시 로그인을 호출하면 로그인 성공 응답이 잘 나오는 걸 확인할 수 있습니다.

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x]  테스트를 작성하고 모두 통과했습니다
- [x]  문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x]  셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 네이버 로그인은 state 검증이 필수이며, 백엔드에서 생성한 state를 그대로 사용해야 합니다.
- state TTL: 5분 (oauth.naver.state-ttl, 기본 300초)
- Authorization Code는 일회용이며 유효 시간이 짧습니다 (약 5분)
- 신규 유저 응답의
 - `naverInfo.name` → 회원가입 개인정보 입력 화면 이름 자동 채움
 - `naverInfo.mobile` → 휴대폰 인증 화면 번호 자동 채움

혹시 회원가입/로그인 오류가 난다면

<img width="832" height="46" alt="스크린샷 2026-01-21 063710" src="https://github.com/user-attachments/assets/91ea45f7-3071-4dd4-bfd1-e29c137d67cc" />

redis ping 테스트를 통해 redis가 연결이 잘 되어있는지 확인해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 네이버 OAuth 로그인 통합 — 인증 URL 생성 및 로그인 처리 엔드포인트 추가
  * 네이버 사용자 정보 포함한 로그인/가입 흐름 지원 및 네이버용 가입 토큰 발급
  * 휴대폰 번호 자동완성·정규화로 onboarding 편의성 향상

* **Bug Fixes**
  * state 검증으로 CSRF 방지 강화 및 불일치 오류 메시지 추가
  * 네이버 API 오류에 대한 명확한 오류 응답 및 토큰 갱신 성공 메시지 개선

* **Chores**
  * 네이버 관련 설정(클라이언트/토큰/리다이렉트/TTL) 및 상태 보관 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->