### PR TITLE
[Feat] 자산 업로드(presigned URL 요청)

### DIFF
--- a/src/main/java/com/proovy/domain/asset/constant/AllowedMimeType.java
+++ b/src/main/java/com/proovy/domain/asset/constant/AllowedMimeType.java
@@ -1,0 +1,35 @@
+package com.proovy.domain.asset.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public enum AllowedMimeType {
+    PDF("application/pdf", "pdf"),
+    PNG("image/png", "png"),
+    JPEG("image/jpeg", "jpg"),
+    WEBP("image/webp", "webp");
+
+    private final String mimeType;
+    private final String extension;
+
+    private static final Set<String> ALLOWED_MIME_TYPES = Arrays.stream(values())
+            .map(AllowedMimeType::getMimeType)
+            .collect(Collectors.toSet());
+
+    public static boolean isAllowed(String mimeType) {
+        return ALLOWED_MIME_TYPES.contains(mimeType);
+    }
+
+    public static AllowedMimeType fromMimeType(String mimeType) {
+        return Arrays.stream(values())
+                .filter(type -> type.getMimeType().equals(mimeType))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unsupported mime type: " + mimeType));
+    }
+}

--- a/src/main/java/com/proovy/domain/asset/controller/AssetsController.java
+++ b/src/main/java/com/proovy/domain/asset/controller/AssetsController.java
@@ -1,0 +1,67 @@
+package com.proovy.domain.asset.controller;
+
+import com.proovy.domain.asset.dto.request.UploadUrlRequest;
+import com.proovy.domain.asset.dto.response.UploadUrlResponse;
+import com.proovy.domain.asset.service.AssetsService;
+import com.proovy.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import com.proovy.global.security.UserPrincipal;
+
+@RestController
+@RequestMapping("/api/assets")
+@RequiredArgsConstructor
+@Tag(name = "Assets", description = "자산(파일) 관리 API")
+public class AssetsController {
+
+    private final AssetsService assetsService;
+
+    @PostMapping("/upload-url")
+    @Operation(
+            summary = "업로드용 Presigned URL 발급",
+            description = """
+                    S3 직접 업로드를 위한 Presigned URL을 발급합니다.
+
+                    **지원 파일 형식**: PDF, PNG, JPEG, WEBP
+                    - application/pdf
+                    - image/png
+                    - image/jpeg
+                    - image/webp
+
+                    **최대 파일 크기**: 30MB (31,457,280 bytes)
+
+                    **URL 유효 시간**: 15분
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "URL 발급 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (ASSET4001: 파일 형식, ASSET4002: 파일 크기, ASSET4005: 파일명)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 (NOTE4031) 또는 용량 초과 (STORAGE4005)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "노트를 찾을 수 없음 (NOTE4041)"
+            )
+    })
+    public ApiResponse<UploadUrlResponse> generateUploadUrl(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody UploadUrlRequest request) {
+
+        UploadUrlResponse response = assetsService.generateUploadUrl(userPrincipal.getUserId(), request);
+        return ApiResponse.success("업로드 URL이 발급되었습니다.", response);
+    }
+}

--- a/src/main/java/com/proovy/domain/asset/dto/request/UploadUrlRequest.java
+++ b/src/main/java/com/proovy/domain/asset/dto/request/UploadUrlRequest.java
@@ -1,0 +1,33 @@
+package com.proovy.domain.asset.dto.request;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UploadUrlRequest {
+
+    @NotNull(message = "노트 ID는 필수입니다.")
+    private Long noteId;
+
+    @NotBlank(message = "파일명은 필수입니다.")
+    @Size(min = 2, message = "파일명은 최소 2자 이상 입력해주세요.")
+    private String fileName;
+
+    @NotBlank(message = "MIME 타입은 필수입니다.")
+    private String mimeType;
+
+    @NotNull(message = "파일 크기는 필수입니다.")
+    @Min(value = 1, message = "파일 크기는 1 이상이어야 합니다.")
+    @Max(value = 31457280, message = "파일 크기는 30MB를 초과할 수 없습니다.")
+    private Long fileSize;
+
+    // 테스트용 생성자
+    public UploadUrlRequest(Long noteId, String fileName, String mimeType, Long fileSize) {
+        this.noteId = noteId;
+        this.fileName = fileName;
+        this.mimeType = mimeType;
+        this.fileSize = fileSize;
+    }
+}

--- a/src/main/java/com/proovy/domain/asset/dto/response/UploadUrlResponse.java
+++ b/src/main/java/com/proovy/domain/asset/dto/response/UploadUrlResponse.java
@@ -1,0 +1,23 @@
+package com.proovy.domain.asset.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UploadUrlResponse {
+
+    private Long assetId;
+    private String uploadUrl;
+    private LocalDateTime expiresAt;
+
+    public static UploadUrlResponse of(Long assetId, String uploadUrl, LocalDateTime expiresAt) {
+        return UploadUrlResponse.builder()
+                .assetId(assetId)
+                .uploadUrl(uploadUrl)
+                .expiresAt(expiresAt)
+                .build();
+    }
+}

--- a/src/main/java/com/proovy/domain/asset/entity/Asset.java
+++ b/src/main/java/com/proovy/domain/asset/entity/Asset.java
@@ -47,6 +47,12 @@ public class Asset {
     @Enumerated(EnumType.STRING)
     private AssetSource source; // upload, ai_generated
 
+    @Column(nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    private AssetStatus status; // PENDING, UPLOADED, FAILED
+
+    private LocalDateTime uploadExpiresAt; // Presigned URL 만료 시간
+
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -57,7 +63,8 @@ public class Asset {
 
     @Builder
     public Asset(Long userId, Long noteId, String fileName, Long fileSize,
-                 String mimeType, String s3Key, String thumbnailS3Key, AssetSource source) {
+                 String mimeType, String s3Key, String thumbnailS3Key, AssetSource source,
+                 AssetStatus status, LocalDateTime uploadExpiresAt) {
         this.userId = userId;
         this.noteId = noteId;
         this.fileName = fileName;
@@ -66,6 +73,8 @@ public class Asset {
         this.s3Key = s3Key;
         this.thumbnailS3Key = thumbnailS3Key;
         this.source = source;
+        this.status = status;
+        this.uploadExpiresAt = uploadExpiresAt;
     }
 
     public enum AssetSource {

--- a/src/main/java/com/proovy/domain/asset/entity/AssetStatus.java
+++ b/src/main/java/com/proovy/domain/asset/entity/AssetStatus.java
@@ -1,0 +1,7 @@
+package com.proovy.domain.asset.entity;
+
+public enum AssetStatus {
+    PENDING,    // Presigned URL 발급됨, 업로드 대기
+    UPLOADED,   // S3 업로드 완료
+    FAILED      // 업로드 실패 또는 만료
+}

--- a/src/main/java/com/proovy/domain/asset/repository/AssetRepository.java
+++ b/src/main/java/com/proovy/domain/asset/repository/AssetRepository.java
@@ -1,6 +1,7 @@
 package com.proovy.domain.asset.repository;
 
 import com.proovy.domain.asset.entity.Asset;
+import com.proovy.domain.asset.entity.AssetStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -29,4 +30,10 @@ public interface AssetRepository extends JpaRepository<Asset, Long> {
      * 특정 노트의 자산 목록 조회
      */
     List<Asset> findAllByNoteId(Long noteId);
+
+    /**
+     * 특정 노트의 특정 상태 자산 파일 크기 합계 조회
+     */
+    @Query("SELECT COALESCE(SUM(a.fileSize), 0) FROM Asset a WHERE a.noteId = :noteId AND a.status = :status")
+    Long sumFileSizeByNoteIdAndStatus(@Param("noteId") Long noteId, @Param("status") AssetStatus status);
 }

--- a/src/main/java/com/proovy/domain/asset/service/AssetsService.java
+++ b/src/main/java/com/proovy/domain/asset/service/AssetsService.java
@@ -1,0 +1,15 @@
+package com.proovy.domain.asset.service;
+
+import com.proovy.domain.asset.dto.request.UploadUrlRequest;
+import com.proovy.domain.asset.dto.response.UploadUrlResponse;
+
+public interface AssetsService {
+
+    /**
+     * S3 업로드용 Presigned URL 발급
+     * @param userId 사용자 ID
+     * @param request 업로드 요청 정보
+     * @return Presigned URL 및 Asset 정보
+     */
+    UploadUrlResponse generateUploadUrl(Long userId, UploadUrlRequest request);
+}

--- a/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
+++ b/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
@@ -1,0 +1,122 @@
+package com.proovy.domain.asset.service;
+
+import com.proovy.domain.asset.constant.AllowedMimeType;
+import com.proovy.domain.asset.dto.request.UploadUrlRequest;
+import com.proovy.domain.asset.dto.response.UploadUrlResponse;
+import com.proovy.domain.asset.entity.Asset;
+import com.proovy.domain.asset.entity.AssetStatus;
+import com.proovy.domain.asset.repository.AssetRepository;
+import com.proovy.domain.note.entity.Note;
+import com.proovy.domain.note.repository.NoteRepository;
+import com.proovy.global.exception.BusinessException;
+import com.proovy.global.infra.s3.S3Service;
+import com.proovy.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AssetsServiceImpl implements AssetsService {
+
+    private final AssetRepository assetRepository;
+    private final NoteRepository noteRepository;
+    private final S3Service s3Service;
+
+    private static final int PRESIGNED_URL_DURATION_MINUTES = 15;
+    private static final long MAX_FILE_SIZE = 31_457_280L; // 30MB
+    private static final long NOTE_STORAGE_LIMIT = 524_288_000L; // 500MB
+
+    @Override
+    @Transactional
+    public UploadUrlResponse generateUploadUrl(Long userId, UploadUrlRequest request) {
+        // 1. 파일 형식 검증 (PDF, PNG, JPEG만 허용)
+        validateMimeType(request.getMimeType());
+
+        // 2. 파일 크기 검증
+        validateFileSize(request.getFileSize());
+
+        // 3. 파일명 검증
+        validateFileName(request.getFileName());
+
+        // 4. 노트 존재 및 권한 검증
+        Note note = noteRepository.findById(request.getNoteId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTE4041));
+
+        if (!note.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.NOTE4031);
+        }
+
+        // 5. 스토리지 용량 검증
+        validateStorageCapacity(request.getNoteId(), request.getFileSize());
+
+        // 6. S3 Key 생성
+        String s3Key = generateS3Key(userId, request.getNoteId(), request.getFileName());
+
+        // 7. Asset 엔티티 생성 (PENDING 상태)
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(PRESIGNED_URL_DURATION_MINUTES);
+
+        Asset asset = Asset.builder()
+                .userId(userId)
+                .noteId(request.getNoteId())
+                .fileName(request.getFileName())
+                .fileSize(request.getFileSize())
+                .mimeType(request.getMimeType())
+                .s3Key(s3Key)
+                .source(Asset.AssetSource.upload)
+                .status(AssetStatus.PENDING)
+                .uploadExpiresAt(expiresAt)
+                .build();
+
+        Asset savedAsset = assetRepository.save(asset);
+
+        // 8. Presigned URL 생성
+        String presignedUrl = s3Service.generatePresignedUploadUrl(
+                s3Key,
+                request.getMimeType(),
+                PRESIGNED_URL_DURATION_MINUTES
+        );
+
+        log.info("[Asset] Presigned URL 발급 완료 - assetId: {}, noteId: {}, userId: {}",
+                savedAsset.getId(), request.getNoteId(), userId);
+
+        return UploadUrlResponse.of(savedAsset.getId(), presignedUrl, expiresAt);
+    }
+
+    private void validateMimeType(String mimeType) {
+        if (!AllowedMimeType.isAllowed(mimeType)) {
+            throw new BusinessException(ErrorCode.ASSET4001);
+        }
+    }
+
+    private void validateFileSize(Long fileSize) {
+        if (fileSize > MAX_FILE_SIZE) {
+            throw new BusinessException(ErrorCode.ASSET4002);
+        }
+    }
+
+    private void validateFileName(String fileName) {
+        if (fileName == null || fileName.length() < 2) {
+            throw new BusinessException(ErrorCode.ASSET4005);
+        }
+    }
+
+    private void validateStorageCapacity(Long noteId, Long fileSize) {
+        Long currentUsage = assetRepository.sumFileSizeByNoteIdAndStatus(noteId, AssetStatus.UPLOADED);
+        if (currentUsage + fileSize > NOTE_STORAGE_LIMIT) {
+            throw new BusinessException(ErrorCode.STORAGE4005);
+        }
+    }
+
+    private String generateS3Key(Long userId, Long noteId, String fileName) {
+        String uuid = UUID.randomUUID().toString();
+        return String.format("users/%d/notes/%d/assets/%s_%s",
+                userId, noteId, uuid, fileName);
+    }
+}

--- a/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
+++ b/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
@@ -101,14 +101,20 @@ public class AssetsServiceImpl implements AssetsService {
         }
     }
 
+    private static final int MAX_FILE_NAME_LENGTH = 255;
+
     private void validateFileName(String fileName) {
-        if (fileName == null || fileName.length() < 2) {
+        if (fileName == null || fileName.trim().length() < 2 || fileName.trim().length() > MAX_FILE_NAME_LENGTH) {
             throw new BusinessException(ErrorCode.ASSET4005);
         }
     }
 
     private void validateStorageCapacity(Long noteId, Long fileSize) {
-        Long currentUsage = assetRepository.sumFileSizeByNoteIdAndStatus(noteId, AssetStatus.UPLOADED);
+        Long uploadedSize = assetRepository.sumFileSizeByNoteIdAndStatus(noteId, AssetStatus.UPLOADED);
+        Long pendingSize = assetRepository.sumFileSizeByNoteIdAndStatus(noteId, AssetStatus.PENDING);
+
+        long currentUsage = (uploadedSize != null ? uploadedSize : 0L) + (pendingSize != null ? pendingSize : 0L);
+
         if (currentUsage + fileSize > NOTE_STORAGE_LIMIT) {
             throw new BusinessException(ErrorCode.STORAGE4005);
         }

--- a/src/main/java/com/proovy/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/proovy/domain/auth/controller/AuthController.java
@@ -122,4 +122,17 @@ public class AuthController {
         TokenDto tokens = authService.refreshToken(request.refreshToken());
         return ResponseEntity.ok(ApiResponse.success("토큰이 갱신되었습니다.", tokens));
     }
+
+    @PostMapping("/dev/token")
+    @Operation(
+            operationId = "99_devToken",
+            summary = "[개발용] 테스트 토큰 발급",
+            description = "개발 환경에서 테스트용 Access Token을 발급합니다. 프로덕션에서는 비활성화해야 합니다.")
+    public ResponseEntity<ApiResponse<TokenDto>> devToken(
+            @RequestParam Long userId
+    ) {
+        log.warn("[DEV] 개발용 토큰 발급 요청 - userId: {}", userId);
+        TokenDto tokens = authService.generateDevToken(userId);
+        return ResponseEntity.ok(ApiResponse.success("개발용 토큰이 발급되었습니다.", tokens));
+    }
 }

--- a/src/main/java/com/proovy/domain/auth/service/AuthService.java
+++ b/src/main/java/com/proovy/domain/auth/service/AuthService.java
@@ -241,4 +241,21 @@ public class AuthService {
                 .build();
         refreshTokenRepository.save(token);
     }
+
+    /**
+     * [개발용] 테스트 토큰 발급
+     * 프로덕션 환경에서는 사용하지 않아야 합니다.
+     */
+    @Transactional
+    public TokenDto generateDevToken(Long userId) {
+        // 유저 존재 확인
+        userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER4041));
+
+        TokenDto tokens = jwtTokenProvider.generateTokens(userId);
+        saveRefreshToken(userId, tokens.refreshToken());
+
+        log.warn("[DEV] 개발용 토큰 발급 완료 - userId: {}", userId);
+        return tokens;
+    }
 }

--- a/src/main/java/com/proovy/domain/storage/controller/StorageController.java
+++ b/src/main/java/com/proovy/domain/storage/controller/StorageController.java
@@ -11,7 +11,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import com.proovy.global.security.UserPrincipal;
 
 @Tag(name = "Storage API", description = "스토리지 관리 관련 API")
 @RestController
@@ -34,12 +36,10 @@ public class StorageController {
     })
     @DeleteMapping("/assets")
     public ResponseEntity<ApiResponse<BulkDeleteResponse>> bulkDeleteAssets(
-            // TODO: JWT 인증 구현 후 @AuthenticationPrincipal로 교체
-            @Parameter(description = "사용자 ID (임시, JWT 인증 구현 후 제거)", example = "1")
-            @RequestParam Long userId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Valid @RequestBody BulkDeleteRequest request
     ) {
-        BulkDeleteResponse response = storageService.bulkDeleteAssets(userId, request);
+        BulkDeleteResponse response = storageService.bulkDeleteAssets(userPrincipal.getUserId(), request);
 
         String message = response.deletedCount() + "개의 파일이 삭제되었습니다.";
         return ResponseEntity.ok(ApiResponse.success(message, response));

--- a/src/main/java/com/proovy/global/config/S3Config.java
+++ b/src/main/java/com/proovy/global/config/S3Config.java
@@ -21,7 +21,7 @@ public class S3Config {
     @Value("${cloud.aws.region.static}")
     private String region;
 
-    @Bean
+    @Bean(destroyMethod = "close")
     public S3Client s3Client() {
         AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
 
@@ -31,7 +31,7 @@ public class S3Config {
                 .build();
     }
 
-    @Bean
+    @Bean(destroyMethod = "close")
     public S3Presigner s3Presigner() {
         AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
 

--- a/src/main/java/com/proovy/global/config/SwaggerConfig.java
+++ b/src/main/java/com/proovy/global/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package com.proovy.global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,8 +14,12 @@ import java.util.List;
 @Configuration
 public class SwaggerConfig {
 
+    private static final String BEARER_TOKEN_PREFIX = "Bearer";
+
     @Bean
     public OpenAPI openAPI() {
+        String securitySchemeName = "bearerAuth";
+
         return new OpenAPI()
                 .info(new Info()
                         .title("Proovy API")
@@ -25,6 +32,15 @@ public class SwaggerConfig {
                         new Server()
                                 .url("https://api.proovy.com")
                                 .description("프로덕션 서버")
-                ));
+                ))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName,
+                                new SecurityScheme()
+                                        .name(securitySchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                                        .description("JWT 액세스 토큰을 입력하세요 (Bearer 접두사 없이)")));
     }
 }

--- a/src/main/java/com/proovy/global/infra/s3/S3Service.java
+++ b/src/main/java/com/proovy/global/infra/s3/S3Service.java
@@ -50,4 +50,13 @@ public interface S3Service {
      * @return 존재 여부
      */
     boolean doesFileExist(String s3Key);
+
+    /**
+     * 파일 업로드용 Presigned URL 생성
+     * @param s3Key S3 저장 경로
+     * @param contentType 파일 타입
+     * @param durationMinutes URL 유효 시간 (분)
+     * @return Presigned URL
+     */
+    String generatePresignedUploadUrl(String s3Key, String contentType, int durationMinutes);
 }

--- a/src/main/java/com/proovy/global/response/ErrorCode.java
+++ b/src/main/java/com/proovy/global/response/ErrorCode.java
@@ -37,7 +37,12 @@ public enum ErrorCode {
 
     // Note
     NOTE4041("NOTE4041", "노트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    NOTE4031("NOTE4031", "노트 접근 권한이 없습니다.", HttpStatus.FORBIDDEN);
+    NOTE4031("NOTE4031", "노트 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+
+    ASSET4001("ASSET4001", "지원하지 않는 파일 형식입니다. PDF만 업로드 가능합니다.", HttpStatus.BAD_REQUEST),
+    ASSET4002("ASSET4002", "파일 크기가 30MB를 초과합니다.", HttpStatus.BAD_REQUEST),
+    ASSET4005("ASSET4005", "파일명은 최소 2자 이상 입력해주세요.", HttpStatus.BAD_REQUEST),
+    STORAGE4005("STORAGE4005", "노트의 스토리지 용량(500MB)을 초과합니다.", HttpStatus.FORBIDDEN);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/proovy/global/response/ErrorCode.java
+++ b/src/main/java/com/proovy/global/response/ErrorCode.java
@@ -39,9 +39,9 @@ public enum ErrorCode {
     NOTE4041("NOTE4041", "노트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     NOTE4031("NOTE4031", "노트 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
-    ASSET4001("ASSET4001", "지원하지 않는 파일 형식입니다. PDF만 업로드 가능합니다.", HttpStatus.BAD_REQUEST),
+    ASSET4001("ASSET4001", "지원하지 않는 파일 형식입니다. PDF, PNG, JPEG, WEBP만 업로드 가능합니다.", HttpStatus.BAD_REQUEST),
     ASSET4002("ASSET4002", "파일 크기가 30MB를 초과합니다.", HttpStatus.BAD_REQUEST),
-    ASSET4005("ASSET4005", "파일명은 최소 2자 이상 입력해주세요.", HttpStatus.BAD_REQUEST),
+    ASSET4005("ASSET4005", "파일명은 2자 이상 255자 이하로 입력해주세요.", HttpStatus.BAD_REQUEST),
     STORAGE4005("STORAGE4005", "노트의 스토리지 용량(500MB)을 초과합니다.", HttpStatus.FORBIDDEN);
 
     private final String code;

--- a/src/main/java/com/proovy/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/proovy/global/security/JwtAuthenticationFilter.java
@@ -39,26 +39,34 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         try {
             String token = resolveToken(request);
+            log.info("[JWT] 요청 URI: {}, 토큰 존재: {}", request.getRequestURI(), token != null);
 
-            if (token != null && jwtTokenProvider.validateAccessToken(token)) {
-                Long userId = jwtTokenProvider.getUserIdFromToken(token);
+            if (token != null) {
+                log.info("[JWT] 토큰 검증 시작...");
+                if (jwtTokenProvider.validateAccessToken(token)) {
+                    Long userId = jwtTokenProvider.getUserIdFromToken(token);
+                    log.info("[JWT] 토큰 검증 성공, userId: {}", userId);
 
-                User user = userRepository.findById(userId)
-                        .orElseThrow(() -> new BusinessException(ErrorCode.USER4041));
+                    User user = userRepository.findById(userId)
+                            .orElseThrow(() -> new BusinessException(ErrorCode.USER4041));
 
-                UserPrincipal principal = new UserPrincipal(user);
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(
-                                principal, null, principal.getAuthorities()
-                        );
-                authentication.setDetails(
-                        new WebAuthenticationDetailsSource().buildDetails(request)
-                );
+                    UserPrincipal principal = new UserPrincipal(user);
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(
+                                    principal, null, principal.getAuthorities()
+                            );
+                    authentication.setDetails(
+                            new WebAuthenticationDetailsSource().buildDetails(request)
+                    );
 
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                    log.info("[JWT] 인증 완료, userId: {}", userId);
+                }
             }
         } catch (BusinessException e) {
-            log.debug("JWT 인증 실패: {}", e.getMessage());
+            log.warn("[JWT] 인증 실패: {}", e.getMessage());
+        } catch (Exception e) {
+            log.error("[JWT] 예외 발생: {}", e.getMessage(), e);
         }
 
         chain.doFilter(request, response);

--- a/src/main/java/com/proovy/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/proovy/global/security/JwtAuthenticationFilter.java
@@ -39,13 +39,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         try {
             String token = resolveToken(request);
-            log.info("[JWT] 요청 URI: {}, 토큰 존재: {}", request.getRequestURI(), token != null);
+            log.debug("[JWT] 요청 URI: {}, 토큰 존재: {}", request.getRequestURI(), token != null);
 
             if (token != null) {
-                log.info("[JWT] 토큰 검증 시작...");
+                log.debug("[JWT] 토큰 검증 시작...");
                 if (jwtTokenProvider.validateAccessToken(token)) {
                     Long userId = jwtTokenProvider.getUserIdFromToken(token);
-                    log.info("[JWT] 토큰 검증 성공, userId: {}", userId);
+                    log.debug("[JWT] 토큰 검증 성공");
 
                     User user = userRepository.findById(userId)
                             .orElseThrow(() -> new BusinessException(ErrorCode.USER4041));
@@ -60,13 +60,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     );
 
                     SecurityContextHolder.getContext().setAuthentication(authentication);
-                    log.info("[JWT] 인증 완료, userId: {}", userId);
+                    log.debug("[JWT] 인증 완료");
                 }
             }
         } catch (BusinessException e) {
-            log.warn("[JWT] 인증 실패: {}", e.getMessage());
+            log.debug("[JWT] 인증 실패: {}", e.getMessage());
         } catch (Exception e) {
-            log.error("[JWT] 예외 발생: {}", e.getMessage(), e);
+            log.warn("[JWT] 예외 발생: {}", e.getMessage());
         }
 
         chain.doFilter(request, response);


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #15 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

1. API 엔드포인트 추가

  - POST /api/assets/upload-url - S3 Presigned URL 발급 API
  - POST /api/auth/dev/token - 개발용 테스트 토큰 발급 API

  2. Presigned URL 발급 로직 구현 (AssetsServiceImpl)

  - 파일 형식 검증 (PDF, PNG, JPEG, WEBP만 허용)
  - 파일 크기 검증 (최대 30MB)
  - 파일명 검증 (최소 2자)
  - 노트 존재 및 권한 검증
  - 노트별 스토리지 용량 검증 (500MB 제한)
  - Asset 엔티티 생성 (PENDING 상태)
  - S3 Presigned URL 생성 (15분 유효)

  3. AWS S3 Presigned URL 연동 (S3ServiceImpl)

  - AWS SDK v2 S3Presigner 사용
  - PutObjectPresignRequest로 업로드용 URL 생성
  - Content-Type 지정으로 파일 형식 제한

  4. JWT 인증 적용

  - AssetsController: @AuthenticationPrincipal UserPrincipal로 사용자 인증
  - StorageController: 동일하게 JWT 인증으로 전환
  - 임시 userId 파라미터 제거

  5. Swagger JWT 인증 설정

  - Bearer Token 인증 스키마 추가
  - Authorize 버튼으로 토큰 입력 가능
  - 전역 Security Requirement 적용

  6. DTO 및 검증

  - UploadUrlRequest:
    - @NotNull noteId: 노트 ID 필수
    - @NotBlank fileName: 파일명 필수
    - @NotNull @Min(1) fileSize: 파일 크기 필수
    - @NotBlank mimeType: MIME 타입 필수
  - UploadUrlResponse:
    - assetId, presignedUrl, expiresAt 반환

  7. Asset 엔티티 확장

  - status 필드 추가 (PENDING, UPLOADED, FAILED)
  - uploadExpiresAt 필드 추가 (URL 만료 시간)

  8. 에러 코드 추가

  - ASSET4001: 지원하지 않는 파일 형식
  - ASSET4002: 파일 크기 30MB 초과
  - ASSET4005: 파일명 최소 2자 필요
  - STORAGE4005: 노트 스토리지 용량(500MB) 초과
  
  9. 인증 관련 로그 추가
   어느 부분에서 에러가 생겼는지 더 자세하게 알 수 있게 추가

## 📸 스크린샷
이거는 swagger test
<img width="887" height="502" alt="스크린샷 2026-01-23 214822" src="https://github.com/user-attachments/assets/8abe68cd-c81f-4b7f-9661-6334e2df1644" />
<img width="879" height="498" alt="스크린샷 2026-01-23 214815" src="https://github.com/user-attachments/assets/1c8c168b-9159-48ba-bd7d-af0b92372c3b" />

DB에 이렇게 저장되어 있을 때,
<img width="1652" height="245" alt="스크린샷 2026-01-24 004028" src="https://github.com/user-attachments/assets/c02aeac5-509a-4c37-a0d2-501437f0ab43" />
<img width="1584" height="128" alt="스크린샷 2026-01-24 003950" src="https://github.com/user-attachments/assets/7f964d60-fbaa-4235-81ff-c06885b6b8d8" />
<img width="699" height="167" alt="스크린샷 2026-01-24 003934" src="https://github.com/user-attachments/assets/0982c797-bcb8-422c-8e8c-385da00b9739" />

발급된 presigned-url을 바탕으로 Git bash로 해당 파일 업로드 테스트 완료헸습니다.

<img width="947" height="601" alt="스크린샷 2026-01-24 003913" src="https://github.com/user-attachments/assets/4c0fe2c5-7435-4df9-b895-ca02097f6a4e" />
<img width="911" height="122" alt="스크린샷 2026-01-24 003831" src="https://github.com/user-attachments/assets/2eadd261-78c0-4f83-8c9f-4a85a1d470bb" />
<img width="933" height="676" alt="스크린샷 2026-01-24 001950" src="https://github.com/user-attachments/assets/32d3bf72-f3f7-4915-904d-7a061c4389b4" />

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

  개발용 토큰 발급 API를 구현했습니다. 
  - 프로덕션 배포 전 제거 해야함
  - POST /api/auth/dev/token?userId={id}로 테스트용 토큰 발급
<img width="899" height="643" alt="image" src="https://github.com/user-attachments/assets/ede73c03-4dda-4d6a-8327-761a466d9d58" />
userid를 입력하고 받은 token 값을 authorize에 넣고 테스트할 수 있습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 클라이언트용 사전 서명 업로드 URL 발급(업로드 URL·만료시간·자산 ID 반환)
  * 개발환경용 액세스 토큰 발급 엔드포인트 추가

* **개선 사항**
  * 업로드 전 MIME 타입·파일명·파일 크기(최대 30MB) 검증 및 노트당 총용량(500MB) 제한 적용
  * 업로드 상태(대기/업로드/실패) 관리 및 저장소 합계 조회 지원
  * Swagger JWT 보안 안내 강화 및 인증 로그 개선, S3 리소스 종료 처리 보완

* **오류 코드**
  * 자산·스토리지 관련 신규 오류 코드 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->