### PR TITLE
Asset credit 관련 오류 수정(max file size, 1024MB)

### DIFF
--- a/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
+++ b/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
@@ -11,6 +11,8 @@ import com.proovy.domain.asset.entity.AssetStatus;
 import com.proovy.domain.asset.repository.AssetRepository;
 import com.proovy.domain.note.entity.Note;
 import com.proovy.domain.note.repository.NoteRepository;
+import com.proovy.domain.user.entity.PlanType;
+import com.proovy.domain.user.repository.UserPlanRepository;
 import com.proovy.global.exception.BusinessException;
 import com.proovy.global.infra.s3.S3Service;
 import com.proovy.global.response.ErrorCode;
@@ -39,6 +41,7 @@ public class AssetsServiceImpl implements AssetsService {
 
     private final AssetRepository assetRepository;
     private final NoteRepository noteRepository;
+    private final UserPlanRepository userPlanRepository;
     private final S3Service s3Service;
     private final WebClient webClient;
     private final ApplicationContext applicationContext;
@@ -54,8 +57,7 @@ public class AssetsServiceImpl implements AssetsService {
     }
 
     private static final int PRESIGNED_URL_DURATION_MINUTES = 15;
-    private static final long MAX_FILE_SIZE = 31_457_280L; // 30MB
-    private static final long NOTE_STORAGE_LIMIT = 524_288_000L; // 500MB
+    private static final long NOTE_STORAGE_LIMIT = 512L * 1024 * 1024; // 512MB (노트당 제한)
     private static final int OCR_TIMEOUT_MINUTES = 30; // OCR 처리 타임아웃
 
     @Override
@@ -64,13 +66,17 @@ public class AssetsServiceImpl implements AssetsService {
         // 1. 파일 형식 검증 (PDF, PNG, JPEG만 허용)
         validateMimeType(request.getMimeType());
 
-        // 2. 파일 크기 검증
-        validateFileSize(request.getFileSize());
+        // 2. 사용자 플랜 조회
+        PlanType planType = userPlanRepository.findActivePlanTypeByUserId(userId)
+                .orElse(PlanType.FREE);
 
-        // 3. 파일명 검증
+        // 3. 파일 크기 검증 (플랜별 제한 적용)
+        validateFileSize(request.getFileSize(), planType);
+
+        // 4. 파일명 검증
         validateFileName(request.getFileName());
 
-        // 4. 노트 존재 및 권한 검증
+        // 5. 노트 존재 및 권한 검증
         Note note = noteRepository.findById(request.getNoteId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOTE4041));
 
@@ -78,13 +84,13 @@ public class AssetsServiceImpl implements AssetsService {
             throw new BusinessException(ErrorCode.NOTE4031);
         }
 
-        // 5. 스토리지 용량 검증
+        // 6. 스토리지 용량 검증
         validateStorageCapacity(request.getNoteId(), request.getFileSize());
 
-        // 6. S3 Key 생성
+        // 7. S3 Key 생성
         String s3Key = generateS3Key(userId, request.getNoteId(), request.getFileName());
 
-        // 7. Asset 엔티티 생성 (PENDING 상태)
+        // 8. Asset 엔티티 생성 (PENDING 상태)
         LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(PRESIGNED_URL_DURATION_MINUTES);
 
         Asset asset = Asset.builder()
@@ -101,7 +107,7 @@ public class AssetsServiceImpl implements AssetsService {
 
         Asset savedAsset = assetRepository.save(asset);
 
-        // 8. Presigned URL 생성
+        // 9. Presigned URL 생성
         String presignedUrl = s3Service.generatePresignedUploadUrl(
                 s3Key,
                 request.getMimeType(),
@@ -120,8 +126,8 @@ public class AssetsServiceImpl implements AssetsService {
         }
     }
 
-    private void validateFileSize(Long fileSize) {
-        if (fileSize > MAX_FILE_SIZE) {
+    private void validateFileSize(Long fileSize, PlanType planType) {
+        if (fileSize > planType.getMaxFileSizeBytes()) {
             throw new BusinessException(ErrorCode.ASSET4002);
         }
     }

--- a/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
+++ b/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
@@ -43,7 +43,6 @@ public class AssetsServiceImpl implements AssetsService {
     private final NoteRepository noteRepository;
     private final UserPlanRepository userPlanRepository;
     private final S3Service s3Service;
-    private final UserPlanRepository userPlanRepository;
 
     private static final int PRESIGNED_URL_DURATION_MINUTES = 15;
     private static final long NOTE_STORAGE_LIMIT = 536_870_912L; // 512MB

--- a/src/main/java/com/proovy/domain/user/entity/PlanType.java
+++ b/src/main/java/com/proovy/domain/user/entity/PlanType.java
@@ -7,14 +7,24 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum PlanType {
-    FREE("free", 3000),        // 3GB = 3000MB
-    PREMIUM("premium", 100000); // 100GB = 100000MB
+    FREE("free", 1024, 10),         // 1GB = 1024MB, maxFileSize = 10MB
+    STANDARD("standard", 5120, 50), // 5GB = 5120MB, maxFileSize = 50MB
+    PRO("pro", 10240, 100);         // 10GB = 10240MB, maxFileSize = 100MB
 
     private final String displayName;
     private final int storageLimitMb;
+    private final int maxFileSizeMb;
 
     @JsonValue
     public String getDisplayName() {
         return displayName;
+    }
+
+    public long getStorageLimitBytes() {
+        return (long) storageLimitMb * 1024 * 1024;
+    }
+
+    public long getMaxFileSizeBytes() {
+        return (long) maxFileSizeMb * 1024 * 1024;
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #45 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

1. PlanType.java 수정

  // 변경 전
  FREE("free", 3000),        // 3GB = 3000MB (잘못된 계산)
  PREMIUM("premium", 100000);

  // 변경 후
  FREE("free", 1024, 10),         // 1GB = 1024MB, maxFileSize = 10MB
  STANDARD("standard", 5120, 50), // 5GB = 5120MB, maxFileSize = 50MB
  PRO("pro", 10240, 100);         // 10GB = 10240MB, maxFileSize = 100MB
  - maxFileSizeMb 필드 추가
  - getStorageLimitBytes(), getMaxFileSizeBytes() 메소드 추가

  2. AssetsServiceImpl.java 수정

  - UserPlanRepository 의존성 추가
  - validateFileSize()에서 플랜별 파일 크기 제한 적용
  - 고정값 MAX_FILE_SIZE 상수 제거

## 📸 스크린샷

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 구독 플랜에 따른 파일 업로드 크기 제한 적용(프리 10MB / 표준 50MB / 프로 100MB)
  * 플랜별 저장소 한도 적용(프리 1GB / 표준 5GB / 프로 10GB)
  * 업로드 URL 발급 시 플랜 기반 검증 적용으로 업로드 정책 일관성 강화
  * 업로드 링크 만료 시간 및 노트 저장·OCR 처리 제한 관련 설정 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->