### PR TITLE
[Feat] 노트 삭제

### DIFF
--- a/src/main/java/com/proovy/domain/asset/repository/AssetRepository.java
+++ b/src/main/java/com/proovy/domain/asset/repository/AssetRepository.java
@@ -3,6 +3,7 @@ package com.proovy.domain.asset.repository;
 import com.proovy.domain.asset.entity.Asset;
 import com.proovy.domain.asset.entity.AssetStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -37,6 +38,19 @@ public interface AssetRepository extends JpaRepository<Asset, Long> {
      * 특정 노트의 자산 목록 조회
      */
     List<Asset> findAllByNoteId(Long noteId);
+
+    /**
+     * 특정 노트의 자산 ID 목록 조회
+     */
+    @Query("SELECT a.id FROM Asset a WHERE a.noteId = :noteId")
+    List<Long> findIdsByNoteId(@Param("noteId") Long noteId);
+
+    /**
+     * 특정 노트의 자산 삭제 (벌크 삭제)
+     */
+    @Modifying
+    @Query("DELETE FROM Asset a WHERE a.noteId = :noteId")
+    void deleteByNoteIdInBulk(@Param("noteId") Long noteId);
 
     /**
      * 특정 노트의 자산 개수 조회

--- a/src/main/java/com/proovy/domain/conversation/repository/ConversationRepository.java
+++ b/src/main/java/com/proovy/domain/conversation/repository/ConversationRepository.java
@@ -2,6 +2,7 @@ package com.proovy.domain.conversation.repository;
 
 import com.proovy.domain.conversation.entity.Conversation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,6 +15,24 @@ public interface ConversationRepository extends JpaRepository<Conversation, Long
      * 특정 노트의 대화 개수 조회
      */
     long countByNoteId(Long noteId);
+
+    /**
+     * 특정 노트의 모든 대화 조회
+     */
+    List<Conversation> findByNoteId(Long noteId);
+
+    /**
+     * 특정 노트의 모든 대화 ID 조회
+     */
+    @Query("SELECT c.id FROM Conversation c WHERE c.note.id = :noteId")
+    List<Long> findIdsByNoteId(@Param("noteId") Long noteId);
+
+    /**
+     * 특정 노트의 모든 대화 삭제 (벌크 삭제)
+     */
+    @Modifying
+    @Query("DELETE FROM Conversation c WHERE c.note.id = :noteId")
+    void deleteByNoteIdInBulk(@Param("noteId") Long noteId);
 
     /**
      * 여러 노트의 대화 개수를 한 번에 조회 (배치 쿼리)

--- a/src/main/java/com/proovy/domain/conversation/repository/MessageAssetRepository.java
+++ b/src/main/java/com/proovy/domain/conversation/repository/MessageAssetRepository.java
@@ -2,7 +2,41 @@ package com.proovy.domain.conversation.repository;
 
 import com.proovy.domain.conversation.entity.MessageAsset;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MessageAssetRepository extends JpaRepository<MessageAsset, Long> {
+
+    /**
+     * 특정 메시지의 모든 자산 연결 조회
+     */
+    List<MessageAsset> findByMessageId(Long messageId);
+
+    /**
+     * 특정 자산을 참조하는 모든 MessageAsset 조회
+     */
+    List<MessageAsset> findByAssetId(Long assetId);
+
+    /**
+     * 특정 자산들을 참조하는 모든 MessageAsset 조회
+     */
+    List<MessageAsset> findByAssetIdIn(List<Long> assetIds);
+
+    /**
+     * 특정 자산들을 참조하는 모든 MessageAsset 삭제 (벌크 삭제)
+     */
+    @Modifying
+    @Query("DELETE FROM MessageAsset ma WHERE ma.asset.id IN :assetIds")
+    void deleteByAssetIdInBulk(@Param("assetIds") List<Long> assetIds);
+
+    /**
+     * 여러 메시지의 모든 자산 연결 삭제 (벌크 삭제)
+     */
+    @Modifying
+    @Query("DELETE FROM MessageAsset ma WHERE ma.message.id IN :messageIds")
+    void deleteByMessageIdInBulk(@Param("messageIds") List<Long> messageIds);
 }
 

--- a/src/main/java/com/proovy/domain/conversation/repository/MessageRepository.java
+++ b/src/main/java/com/proovy/domain/conversation/repository/MessageRepository.java
@@ -2,7 +2,36 @@ package com.proovy.domain.conversation.repository;
 
 import com.proovy.domain.conversation.entity.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
+
+    /**
+     * 특정 대화의 모든 메시지 조회
+     */
+    List<Message> findByConversationId(Long conversationId);
+
+    /**
+     * 특정 대화의 모든 메시지 ID 조회
+     */
+    @Query("SELECT m.id FROM Message m WHERE m.conversation.id = :conversationId")
+    List<Long> findIdsByConversationId(@Param("conversationId") Long conversationId);
+
+    /**
+     * 여러 대화의 모든 메시지 ID 조회
+     */
+    @Query("SELECT m.id FROM Message m WHERE m.conversation.id IN :conversationIds")
+    List<Long> findIdsByConversationIdIn(@Param("conversationIds") List<Long> conversationIds);
+
+    /**
+     * 특정 대화들의 모든 메시지 삭제 (벌크 삭제)
+     */
+    @Modifying
+    @Query("DELETE FROM Message m WHERE m.conversation.id IN :conversationIds")
+    void deleteByConversationIdInBulk(@Param("conversationIds") List<Long> conversationIds);
 }
 

--- a/src/main/java/com/proovy/domain/conversation/repository/MessageToolRepository.java
+++ b/src/main/java/com/proovy/domain/conversation/repository/MessageToolRepository.java
@@ -2,7 +2,24 @@ package com.proovy.domain.conversation.repository;
 
 import com.proovy.domain.conversation.entity.MessageTool;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MessageToolRepository extends JpaRepository<MessageTool, Long> {
+
+    /**
+     * 특정 메시지의 모든 도구 연결 조회
+     */
+    List<MessageTool> findByMessageId(Long messageId);
+
+    /**
+     * 여러 메시지의 모든 도구 연결 삭제 (벌크 삭제)
+     */
+    @Modifying
+    @Query("DELETE FROM MessageTool mt WHERE mt.message.id IN :messageIds")
+    void deleteByMessageIdInBulk(@Param("messageIds") List<Long> messageIds);
 }
 

--- a/src/main/java/com/proovy/domain/note/dto/response/DeleteNoteResponse.java
+++ b/src/main/java/com/proovy/domain/note/dto/response/DeleteNoteResponse.java
@@ -1,0 +1,13 @@
+package com.proovy.domain.note.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record DeleteNoteResponse(
+        Long deletedNoteId,
+        Integer deletedConversationCount,
+        Integer deletedAssetCount,
+        Long freedStorageBytes
+) {
+}
+

--- a/src/main/java/com/proovy/domain/note/service/NoteService.java
+++ b/src/main/java/com/proovy/domain/note/service/NoteService.java
@@ -3,6 +3,7 @@ package com.proovy.domain.note.service;
 import com.proovy.domain.note.dto.request.CreateNoteRequest;
 import com.proovy.domain.note.dto.request.UpdateNoteTitleRequest;
 import com.proovy.domain.note.dto.response.CreateNoteResponse;
+import com.proovy.domain.note.dto.response.DeleteNoteResponse;
 import com.proovy.domain.note.dto.response.NoteListResponse;
 import com.proovy.domain.note.dto.response.UpdateNoteTitleResponse;
 
@@ -12,5 +13,7 @@ public interface NoteService {
     NoteListResponse getNoteList(Long userId, int page, int size, String sort);
 
     UpdateNoteTitleResponse updateNoteTitle(Long userId, Long noteId, UpdateNoteTitleRequest request);
+
+    DeleteNoteResponse deleteNote(Long userId, Long noteId);
 }
 

--- a/src/main/java/com/proovy/global/response/ErrorCode.java
+++ b/src/main/java/com/proovy/global/response/ErrorCode.java
@@ -45,6 +45,7 @@ public enum ErrorCode {
     NOTE4002("NOTE4002", "노트 제목을 입력해주세요.", HttpStatus.BAD_REQUEST),
     NOTE4041("NOTE4041", "노트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     NOTE4031("NOTE4031", "노트 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    NOTE4032("NOTE4032", "해당 노트에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
     ASSET4001("ASSET4001", "지원하지 않는 파일 형식입니다. PDF, PNG, JPEG, WEBP만 업로드 가능합니다.", HttpStatus.BAD_REQUEST),
     ASSET4002("ASSET4002", "파일 크기가 플랜 제한을 초과합니다.", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #57 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 작업한 주요 내용을 bullet point로 정리해주세요.
- 예: 리뷰 작성 API 개발
- 예: Prisma 모델 수정

## 📸 스크린샷

삭제 전 DB
![삭제 전 DB](https://github.com/user-attachments/assets/91649cf1-808e-4ed6-927e-56acf9d012e2)

노트 삭제
<img width="1733" height="2219" alt="노트 삭제" src="https://github.com/user-attachments/assets/ee9b7e10-9e8d-4862-b25f-ea3af3f3a2b0" />

삭제 후 DB
![삭제 후](https://github.com/user-attachments/assets/8626c929-c8ab-4be0-a472-f0bf0aee5a69)

삭제 시 내부 Hibernate 쿼리 동작

```
2026-01-27T09:16:02.904+09:00  INFO 40512 --- [proovy-api] [nio-8080-exec-7] c.p.d.note.controller.NoteController     : 노트 삭제 요청 - userId: 7, noteId: 1
2026-01-27T09:16:02.905+09:00  INFO 40512 --- [proovy-api] [nio-8080-exec-7] c.p.domain.note.service.NoteServiceImpl  : 노트 삭제 요청 - userId: 7, noteId: 1
Hibernate: 
    select
        n1_0.note_id,
        n1_0.content_md,
        n1_0.created_at,
        n1_0.title,
        n1_0.updated_at,
        n1_0.user_id 
    from
        notes n1_0 
    where
        n1_0.note_id=?
Hibernate: 
    select
        count(c1_0.conversation_id) 
    from
        conversations c1_0 
    left join
        notes n1_0 
            on n1_0.note_id=c1_0.note_id 
    where
        n1_0.note_id=?
Hibernate: 
    select
        a1_0.id,
        a1_0.created_at,
        a1_0.file_name,
        a1_0.file_size,
        a1_0.mime_type,
        a1_0.note_id,
        a1_0.ocr_processed_at,
        a1_0.ocr_status,
        a1_0.ocr_text,
        a1_0.s3key,
        a1_0.source,
        a1_0.status,
        a1_0.thumbnails3key,
        a1_0.total_pages,
        a1_0.updated_at,
        a1_0.upload_expires_at,
        a1_0.user_id,
        a1_0.version 
    from
        assets a1_0 
    where
        a1_0.note_id=?
2026-01-27T09:16:03.451+09:00  INFO 40512 --- [proovy-api] [nio-8080-exec-7] c.proovy.global.infra.s3.S3ServiceImpl   : [S3] 파일 일괄 삭제 성공: 2 개
2026-01-27T09:16:03.451+09:00  INFO 40512 --- [proovy-api] [nio-8080-exec-7] c.p.domain.note.service.NoteServiceImpl  : S3 파일 삭제 완료 - 2 개 파일
Hibernate: 
    select
        c1_0.conversation_id 
    from
        conversations c1_0 
    where
        c1_0.note_id=?
Hibernate: 
    select
        m1_0.message_id 
    from
        messages m1_0 
    where
        m1_0.conversation_id in (?)
Hibernate: 
    delete 
    from
        message_assets ma1_0 
    where
        ma1_0.asset_id in (?)
2026-01-27T09:16:03.481+09:00  INFO 40512 --- [proovy-api] [nio-8080-exec-7] c.p.domain.note.service.NoteServiceImpl  : Asset 관련 MessageAsset 삭제 완료
Hibernate: 
    delete 
    from
        message_assets ma1_0 
    where
        ma1_0.message_id in (?, ?)
2026-01-27T09:16:03.485+09:00  INFO 40512 --- [proovy-api] [nio-8080-exec-7] c.p.domain.note.service.NoteServiceImpl  : Message 관련 MessageAsset 삭제 완료
Hibernate: 
    delete 
    from
        message_tools mt1_0 
    where
        mt1_0.message_id in (?, ?)
2026-01-27T09:16:03.490+09:00  INFO 40512 --- [proovy-api] [nio-8080-exec-7] c.p.domain.note.service.NoteServiceImpl  : MessageTool 삭제 완료
Hibernate: 
    delete 
    from
        messages m1_0 
    where
        m1_0.conversation_id in (?)
2026-01-27T09:16:03.493+09:00  INFO 40512 --- [proovy-api] [nio-8080-exec-7] c.p.domain.note.service.NoteServiceImpl  : Message 삭제 완료
Hibernate: 
    delete 
    from
        conversations c1_0 
    where
        c1_0.note_id=?
2026-01-27T09:16:03.498+09:00  INFO 40512 --- [proovy-api] [nio-8080-exec-7] c.p.domain.note.service.NoteServiceImpl  : 대화 삭제 완료 - 1 개
Hibernate: 
    delete 
    from
        assets a1_0 
    where
        a1_0.note_id=?
2026-01-27T09:16:03.501+09:00  INFO 40512 --- [proovy-api] [nio-8080-exec-7] c.p.domain.note.service.NoteServiceImpl  : 자산 삭제 완료 - 1 개
2026-01-27T09:16:03.509+09:00  INFO 40512 --- [proovy-api] [nio-8080-exec-7] c.p.domain.note.service.NoteServiceImpl  : 노트 삭제 완료 - noteId: 1, conversations: 1, assets: 1, freedStorage: 1048576 bytes
Hibernate: 
    delete 
    from
        notes 
    where
        note_id=?
```

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능

* 노트 삭제 기능이 추가되었습니다. 사용자가 노트를 삭제할 때, 연결된 모든 대화, 메시지, 자산과 관련된 저장된 파일들이 자동으로 함께 삭제되며, 차지하던 저장 공간이 모두 반환됩니다. 본인이 소유한 노트만 삭제할 수 있으며, 권한이 없는 경우에는 접근이 거부됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->