### PR TITLE
[Feat] @멘션용 도구 목록 조회

### DIFF
--- a/src/main/java/com/proovy/domain/note/controller/NoteController.java
+++ b/src/main/java/com/proovy/domain/note/controller/NoteController.java
@@ -5,7 +5,6 @@ import com.proovy.domain.note.dto.request.UpdateNoteTitleRequest;
 import com.proovy.domain.note.dto.response.CreateNoteResponse;
 import com.proovy.domain.note.dto.response.DeleteNoteResponse;
 import com.proovy.domain.note.dto.response.NoteDetailResponse;
-import com.proovy.domain.note.dto.response.DeleteNoteResponse;
 import com.proovy.domain.note.dto.response.NoteListResponse;
 import com.proovy.domain.note.dto.response.ToolListResponse;
 import com.proovy.domain.note.dto.response.UpdateNoteTitleResponse;
@@ -267,8 +266,13 @@ public class NoteController {
                     - VARIATION: 변형 문제 생성하기 - 유사 유형 변형 문제 생성
                     
                     **검색 기능**
-                    - query 파라미터로 도구 이름 검색 가능 (자동완성용)
+                    - query 파라미터로 도구 이름 또는 toolCode 검색 가능 (자동완성용)
                     - 검색어가 없으면 전체 활성화된 도구 목록 반환
+                    
+                    **사용 예시**
+                    - `GET /api/notes/tools` : 전체 도구 목록
+                    - `GET /api/notes/tools?query=그래` : "그래프"가 포함된 도구 검색
+                    - `GET /api/notes/tools?query=SOLUTION` : toolCode로 검색
                     """
     )
     @ApiResponses({

--- a/src/main/java/com/proovy/domain/note/dto/response/ToolListResponse.java
+++ b/src/main/java/com/proovy/domain/note/dto/response/ToolListResponse.java
@@ -1,0 +1,66 @@
+package com.proovy.domain.note.dto.response;
+
+import com.proovy.global.tool.entity.Tool;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@Schema(description = "도구 목록 조회 응답")
+public class ToolListResponse {
+
+    @Schema(description = "도구 목록")
+    private List<ToolInfo> tools;
+
+    @Getter
+    @Builder
+    @Schema(description = "도구 정보")
+    public static class ToolInfo {
+        @Schema(description = "도구 고유 ID", example = "1")
+        private Long toolId;
+
+        @Schema(description = "도구 식별 코드", example = "GRAPH")
+        private String toolCode;
+
+        @Schema(description = "도구 표시 이름", example = "그래프 그리기")
+        private String name;
+
+        @Schema(description = "도구 기능 설명", example = "입력한 수식을 바탕으로 시각적인 함수 그래프를 생성합니다.")
+        private String description;
+
+        @Schema(description = "UI 아이콘 타입", example = "chart_line")
+        private String iconType;
+
+        @Schema(description = "도구 활성화 여부", example = "true")
+        private Boolean isActive;
+
+        @Schema(description = "드롭다운 표시 순서", example = "1")
+        private Integer displayOrder;
+
+        public static ToolInfo from(Tool tool) {
+            return ToolInfo.builder()
+                    .toolId(tool.getId())
+                    .toolCode(tool.getToolCode())
+                    .name(tool.getName())
+                    .description(tool.getDescription())
+                    .iconType(tool.getIconType())
+                    .isActive(tool.getIsActive())
+                    .displayOrder(tool.getDisplayOrder())
+                    .build();
+        }
+    }
+
+    public static ToolListResponse from(List<Tool> tools) {
+        List<ToolInfo> toolInfos = tools.stream()
+                .map(ToolInfo::from)
+                .collect(Collectors.toList());
+
+        return ToolListResponse.builder()
+                .tools(toolInfos)
+                .build();
+    }
+}

--- a/src/main/java/com/proovy/global/tool/config/ToolDataInitializer.java
+++ b/src/main/java/com/proovy/global/tool/config/ToolDataInitializer.java
@@ -1,0 +1,62 @@
+package com.proovy.global.tool.config;
+
+import com.proovy.global.tool.entity.Tool;
+import com.proovy.global.tool.repository.ToolRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ToolDataInitializer implements CommandLineRunner {
+
+    private final ToolRepository toolRepository;
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+        // 이미 데이터가 있으면 초기화하지 않음
+        if (toolRepository.count() > 0) {
+            log.info("도구 데이터가 이미 존재합니다. 초기화를 건너뜁니다.");
+            return;
+        }
+
+        log.info("도구 초기 데이터를 생성합니다...");
+
+        List<Tool> tools = List.of(
+                Tool.builder()
+                        .toolCode("GRAPH")
+                        .name("그래프 그리기")
+                        .description("입력한 수식을 바탕으로 시각적인 함수 그래프를 생성합니다.")
+                        .iconType("chart_line")
+                        .isActive(true)
+                        .displayOrder(1)
+                        .build(),
+                Tool.builder()
+                        .toolCode("SOLUTION")
+                        .name("해설지 생성하기")
+                        .description("문제에 대한 단계별 풀이 과정과 정답 해설지를 생성합니다.")
+                        .iconType("file_text")
+                        .isActive(true)
+                        .displayOrder(2)
+                        .build(),
+                Tool.builder()
+                        .toolCode("VARIATION")
+                        .name("변형 문제 생성하기")
+                        .description("기존 문제를 바탕으로 유사한 유형의 변형 문제를 생성합니다.")
+                        .iconType("copy_plus")
+                        .isActive(true)
+                        .displayOrder(3)
+                        .build()
+        );
+
+        toolRepository.saveAll(tools);
+        log.info("도구 초기 데이터 생성 완료: {} 개", tools.size());
+    }
+}
+

--- a/src/main/java/com/proovy/global/tool/entity/Tool.java
+++ b/src/main/java/com/proovy/global/tool/entity/Tool.java
@@ -1,0 +1,62 @@
+package com.proovy.global.tool.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tools")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Tool {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tool_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String toolCode;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(length = 50)
+    private String iconType;
+
+    @Column(nullable = false)
+    private Boolean isActive = true;
+
+    @Column(nullable = false)
+    private Integer displayOrder = 0;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Tool(String toolCode, String name, String description, String iconType, Boolean isActive, Integer displayOrder) {
+        this.toolCode = toolCode;
+        this.name = name;
+        this.description = description;
+        this.iconType = iconType;
+        this.isActive = isActive != null ? isActive : true;
+        this.displayOrder = displayOrder != null ? displayOrder : 0;
+    }
+}
+

--- a/src/main/java/com/proovy/global/tool/repository/ToolRepository.java
+++ b/src/main/java/com/proovy/global/tool/repository/ToolRepository.java
@@ -1,0 +1,25 @@
+package com.proovy.global.tool.repository;
+
+import com.proovy.global.tool.entity.Tool;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ToolRepository extends JpaRepository<Tool, Long> {
+
+    /**
+     * 활성화된 도구 목록 조회 (표시 순서대로)
+     */
+    List<Tool> findByIsActiveTrueOrderByDisplayOrder();
+
+    /**
+     * 도구 이름으로 검색 (자동완성용)
+     */
+    @Query("SELECT t FROM Tool t WHERE t.isActive = true " +
+           "AND LOWER(t.name) LIKE LOWER(CONCAT('%', :query, '%')) " +
+           "ORDER BY t.displayOrder")
+    List<Tool> searchByNameQuery(@Param("query") String query);
+}
+

--- a/src/main/java/com/proovy/global/tool/repository/ToolRepository.java
+++ b/src/main/java/com/proovy/global/tool/repository/ToolRepository.java
@@ -15,10 +15,12 @@ public interface ToolRepository extends JpaRepository<Tool, Long> {
     List<Tool> findByIsActiveTrueOrderByDisplayOrder();
 
     /**
-     * 도구 이름으로 검색 (자동완성용)
+     * 도구 이름 또는 toolCode로 검색 (자동완성용)
+     * @param query 검색어 (name 또는 toolCode에서 부분 일치 검색)
      */
     @Query("SELECT t FROM Tool t WHERE t.isActive = true " +
-           "AND LOWER(t.name) LIKE LOWER(CONCAT('%', :query, '%')) " +
+           "AND (LOWER(t.name) LIKE LOWER(CONCAT('%', :query, '%')) " +
+           "OR LOWER(t.toolCode) LIKE LOWER(CONCAT('%', :query, '%'))) " +
            "ORDER BY t.displayOrder")
     List<Tool> searchByNameQuery(@Param("query") String query);
 }

--- a/src/main/java/com/proovy/global/tool/service/ToolService.java
+++ b/src/main/java/com/proovy/global/tool/service/ToolService.java
@@ -1,0 +1,35 @@
+package com.proovy.global.tool.service;
+
+import com.proovy.global.tool.entity.Tool;
+import com.proovy.global.tool.repository.ToolRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ToolService {
+
+    private final ToolRepository toolRepository;
+
+    /**
+     * 도구 목록 조회 (검색어 지원)
+     */
+    public List<Tool> getToolList(String query) {
+        log.debug("도구 목록 조회 요청 - query: {}", query);
+
+        if (query != null && !query.trim().isEmpty()) {
+            // 검색어가 있으면 이름으로 검색
+            return toolRepository.searchByNameQuery(query.trim());
+        } else {
+            // 검색어가 없으면 전체 활성화된 도구 조회
+            return toolRepository.findByIsActiveTrueOrderByDisplayOrder();
+        }
+    }
+}
+


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #58 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- GET /api/notes/tools
- Controller: NoteController (Note 도메인)
- Service: ToolService (global.tool 공통 모듈)

도구 목록 조회
- 활성화된 모든 도구 조회 (displayOrder 순서)
- Query Parameter query로 이름 검색 지원 (자동완성)
- 3가지 도구 자동 초기화: GRAPH, SOLUTION, VARIATION

tool이라는걸 note 혹은 conversation 도메인에 포함시키기에는 DDD 아키텍처에 맞지 않아 global에 추가하였고, note에 관련된 API를 note 도메인에 남겼습니다.

global.tool
```
src/main/java/com/proovy/global/tool/
├── entity/
│   └── Tool.java               # Tool 엔티티
├── repository/
│   └── ToolRepository.java     # Tool Repository (JPA)
├── service/
│   └── ToolService.java        # Tool Service (비즈니스 로직)
└── config/
    └── ToolDataInitializer.java # 초기 데이터 생성
```

Note 도메인
```
src/main/java/com/proovy/domain/note/
├── controller/
│   └── NoteController.java     # GET /api/notes/tools 엔드포인트 추가
└── dto/response/
    └── ToolListResponse.java   # 도구 목록 응답 DTO
```

## 📸 스크린샷

'해설' 이라고 검색하면 '해설지 생성하기' 가 응답되게 됩니다.
<img width="1733" height="2298" alt="사용가능한 도구 목록 조회" src="https://github.com/user-attachments/assets/ddcc5ccd-4cb2-488a-8f87-30ef2c6794a8" />


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 도구 목록 조회 API 추가: 사용 가능한 도구를 조회하고 이름으로 선택 검색 가능.
  * 도구 응답에 도구 ID/코드, 이름, 설명, 아이콘 타입, 활성 여부, 표시순서 등이 포함됨.
  * 앱 시작 시 기본 도구 데이터가 자동으로 초기화되어 활성 도구를 표시 순서대로 제공합니다.
* **문서**
  * 신규 도구 조회 API가 OpenAPI/Swagger 문서에 반영되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->