### PR TITLE
[Feat] 서비스 탈퇴(계정 삭제) API 구현

### DIFF
--- a/src/main/java/com/proovy/domain/asset/repository/AssetRepository.java
+++ b/src/main/java/com/proovy/domain/asset/repository/AssetRepository.java
@@ -49,4 +49,9 @@ public interface AssetRepository extends JpaRepository<Asset, Long> {
      * OCR 상태가 특정 값이고 updatedAt이 특정 시각 이전인 자산 목록 조회 (타임아웃 처리용)
      */
     List<Asset> findByOcrStatusAndUpdatedAtBefore(Asset.OcrStatus ocrStatus, LocalDateTime threshold);
+
+    /**
+     * 특정 사용자의 모든 자산 삭제 (회원 탈퇴용)
+     */
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/proovy/domain/note/repository/NoteRepository.java
+++ b/src/main/java/com/proovy/domain/note/repository/NoteRepository.java
@@ -2,6 +2,7 @@ package com.proovy.domain.note.repository;
 
 import com.proovy.domain.note.entity.Note;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,4 +16,11 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
            "AND LOWER(n.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
            "ORDER BY n.createdAt DESC")
     List<Note> searchByTitleKeyword(@Param("userId") Long userId, @Param("keyword") String keyword);
+
+    /**
+     * 특정 사용자의 모든 노트 삭제 (회원 탈퇴용)
+     */
+    @Modifying
+    @Query("DELETE FROM Note n WHERE n.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/proovy/domain/note/repository/NoteRepository.java
+++ b/src/main/java/com/proovy/domain/note/repository/NoteRepository.java
@@ -24,7 +24,7 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
     /**
      * 특정 사용자의 모든 노트 삭제 (회원 탈퇴용)
      */
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Note n WHERE n.user.id = :userId")
     void deleteAllByUserId(@Param("userId") Long userId);
 

--- a/src/main/java/com/proovy/domain/user/controller/UserController.java
+++ b/src/main/java/com/proovy/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.proovy.domain.user.controller;
 
+import com.proovy.domain.user.dto.response.DeleteUserResponse;
 import com.proovy.domain.user.dto.response.MyProfileResponse;
 import com.proovy.domain.user.dto.response.SubscriptionResponse;
 import com.proovy.domain.user.service.SubscriptionService;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -75,5 +77,24 @@ public class UserController {
     ) {
         SubscriptionResponse response = subscriptionService.getSubscription(userPrincipal.getUserId());
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/me")
+    @Operation(
+            operationId = "04_deleteUser",
+            summary = "회원 탈퇴",
+            description = "현재 로그인한 사용자의 계정을 영구 삭제합니다. 모든 노트, 파일, 구독 정보가 삭제됩니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "탈퇴 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "활성 구독 존재 (USER4004)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 (AUTH4013)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자 없음 (USER4041)")
+    })
+    public ResponseEntity<ApiResponse<DeleteUserResponse>> deleteUser(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal.getUserId();
+        DeleteUserResponse response = userService.deleteUser(userId);
+        return ResponseEntity.ok(ApiResponse.success("회원 탈퇴가 완료되었습니다.", response));
     }
 }

--- a/src/main/java/com/proovy/domain/user/controller/UserController.java
+++ b/src/main/java/com/proovy/domain/user/controller/UserController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -91,10 +92,20 @@ public class UserController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자 없음 (USER4041)")
     })
     public ResponseEntity<ApiResponse<DeleteUserResponse>> deleteUser(
-            @AuthenticationPrincipal UserPrincipal userPrincipal
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            HttpServletRequest request
     ) {
         Long userId = userPrincipal.getUserId();
-        DeleteUserResponse response = userService.deleteUser(userId);
+        String accessToken = extractAccessToken(request);
+        DeleteUserResponse response = userService.deleteUser(userId, accessToken);
         return ResponseEntity.ok(ApiResponse.success("회원 탈퇴가 완료되었습니다.", response));
+    }
+
+    private String extractAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
     }
 }

--- a/src/main/java/com/proovy/domain/user/controller/UserController.java
+++ b/src/main/java/com/proovy/domain/user/controller/UserController.java
@@ -81,7 +81,7 @@ public class UserController {
 
     @DeleteMapping("/me")
     @Operation(
-            operationId = "04_deleteUser",
+            operationId = "03_deleteUser",
             summary = "회원 탈퇴",
             description = "현재 로그인한 사용자의 계정을 영구 삭제합니다. 모든 노트, 파일, 구독 정보가 삭제됩니다.")
     @ApiResponses({

--- a/src/main/java/com/proovy/domain/user/dto/response/DeleteUserResponse.java
+++ b/src/main/java/com/proovy/domain/user/dto/response/DeleteUserResponse.java
@@ -1,0 +1,14 @@
+package com.proovy.domain.user.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record DeleteUserResponse(
+        String deletedAt
+) {
+    public static DeleteUserResponse of(String deletedAt) {
+        return DeleteUserResponse.builder()
+                .deletedAt(deletedAt)
+                .build();
+    }
+}

--- a/src/main/java/com/proovy/domain/user/repository/UserPlanRepository.java
+++ b/src/main/java/com/proovy/domain/user/repository/UserPlanRepository.java
@@ -3,6 +3,7 @@ package com.proovy.domain.user.repository;
 import com.proovy.domain.user.entity.PlanType;
 import com.proovy.domain.user.entity.UserPlan;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,4 +16,11 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, Long> {
 
     @Query("SELECT up.planType FROM UserPlan up WHERE up.user.id = :userId AND up.isActive = true ORDER BY up.startedAt DESC LIMIT 1")
     Optional<PlanType> findActivePlanTypeByUserId(@Param("userId") Long userId);
+
+    /**
+     * 특정 사용자의 모든 플랜 삭제 (회원 탈퇴용)
+     */
+    @Modifying
+    @Query("DELETE FROM UserPlan up WHERE up.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/proovy/domain/user/repository/UserPlanRepository.java
+++ b/src/main/java/com/proovy/domain/user/repository/UserPlanRepository.java
@@ -20,7 +20,7 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, Long> {
     /**
      * 특정 사용자의 모든 플랜 삭제 (회원 탈퇴용)
      */
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM UserPlan up WHERE up.user.id = :userId")
     void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/proovy/domain/user/service/UserService.java
+++ b/src/main/java/com/proovy/domain/user/service/UserService.java
@@ -160,10 +160,16 @@ public class UserService {
     }
 
     private void deleteUserData(Long userId) {
-        // S3 키를 먼저 수집
-        List<String> s3Keys = assetRepository.findAllByUserId(userId).stream()
-                .map(asset -> asset.getS3Key())
-                .collect(Collectors.toList());
+        // S3 키를 먼저 수집 (원본 + 썸네일)
+        List<String> s3Keys = new java.util.ArrayList<>();
+        assetRepository.findAllByUserId(userId).forEach(asset -> {
+            if (asset.getS3Key() != null) {
+                s3Keys.add(asset.getS3Key());
+            }
+            if (asset.getThumbnailS3Key() != null) {
+                s3Keys.add(asset.getThumbnailS3Key());
+            }
+        });
 
         // DB 데이터 삭제
         assetRepository.deleteAllByUserId(userId);

--- a/src/main/java/com/proovy/domain/user/service/UserService.java
+++ b/src/main/java/com/proovy/domain/user/service/UserService.java
@@ -149,8 +149,14 @@ public class UserService {
         userRepository.delete(user);
 
         // 5. 토큰 무효화
-        accessTokenBlacklistService.blacklist(accessToken, userId);
         refreshTokenRepository.deleteByUserId(userId);
+        // Access Token 블랙리스트는 Redis 기반이므로 커밋 이후 실행
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                accessTokenBlacklistService.blacklist(accessToken, userId);
+            }
+        });
 
         log.info("사용자 탈퇴 완료: userId={}", userId);
 

--- a/src/main/java/com/proovy/domain/user/service/UserService.java
+++ b/src/main/java/com/proovy/domain/user/service/UserService.java
@@ -1,13 +1,17 @@
 package com.proovy.domain.user.service;
 
 import com.proovy.domain.asset.repository.AssetRepository;
+import com.proovy.domain.note.repository.NoteRepository;
+import com.proovy.domain.user.dto.response.DeleteUserResponse;
 import com.proovy.domain.user.dto.response.MyProfileResponse;
 import com.proovy.domain.user.dto.response.MyProfileResponse.*;
 import com.proovy.domain.user.entity.PlanType;
 import com.proovy.domain.user.entity.User;
+import com.proovy.domain.user.entity.UserPlan;
 import com.proovy.domain.user.repository.UserPlanRepository;
 import com.proovy.domain.user.repository.UserRepository;
 import com.proovy.global.exception.BusinessException;
+import com.proovy.global.infra.s3.S3Service;
 import com.proovy.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -27,6 +32,8 @@ public class UserService {
     private final UserRepository userRepository;
     private final UserPlanRepository userPlanRepository;
     private final AssetRepository assetRepository;
+    private final NoteRepository noteRepository;
+    private final S3Service s3Service;
 
     /**
      * 내 프로필 조회
@@ -110,5 +117,49 @@ public class UserService {
     private String formatDate(LocalDateTime dateTime) {
         if (dateTime == null) return null;
         return dateTime.toLocalDate().format(DateTimeFormatter.ISO_LOCAL_DATE);
+    }
+
+    /**
+     * 회원 탈퇴
+     */
+    @Transactional
+    public DeleteUserResponse deleteUser(Long userId) {
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER4041));
+
+        // 2. 활성 구독 확인 (FREE가 아닌 플랜이 활성 상태면 탈퇴 불가)
+        Optional<UserPlan> activePlan = userPlanRepository.findActiveByUserId(userId);
+        if (activePlan.isPresent() && activePlan.get().getPlanType() != PlanType.FREE) {
+            throw new BusinessException(ErrorCode.USER4004);
+        }
+
+        // 3. 사용자 관련 데이터 삭제
+        deleteUserData(userId);
+
+        // 4. 사용자 삭제
+        userRepository.delete(user);
+
+        log.info("사용자 탈퇴 완료: userId={}", userId);
+
+        return DeleteUserResponse.of(
+                LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        );
+    }
+
+    private void deleteUserData(Long userId) {
+        // S3 파일 삭제
+        assetRepository.findAllByUserId(userId).forEach(asset -> {
+            try {
+                s3Service.deleteFile(asset.getS3Key());
+            } catch (Exception e) {
+                log.warn("S3 파일 삭제 실패: s3Key={}", asset.getS3Key(), e);
+            }
+        });
+
+        // DB 데이터 삭제
+        assetRepository.deleteAllByUserId(userId);
+        noteRepository.deleteAllByUserId(userId);
+        userPlanRepository.deleteAllByUserId(userId);
     }
 }

--- a/src/main/java/com/proovy/domain/user/service/UserService.java
+++ b/src/main/java/com/proovy/domain/user/service/UserService.java
@@ -154,7 +154,11 @@ public class UserService {
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                accessTokenBlacklistService.blacklist(accessToken, userId);
+                try {
+                    accessTokenBlacklistService.blacklist(accessToken, userId);
+                } catch (Exception e) {
+                    log.warn("Access Token 블랙리스트 실패: userId={}", userId, e);
+                }
             }
         });
 

--- a/src/main/java/com/proovy/domain/user/service/UserService.java
+++ b/src/main/java/com/proovy/domain/user/service/UserService.java
@@ -155,7 +155,9 @@ public class UserService {
             @Override
             public void afterCommit() {
                 try {
-                    accessTokenBlacklistService.blacklist(accessToken, userId);
+                    if (accessToken != null) {
+                        accessTokenBlacklistService.blacklist(accessToken, userId);
+                    }
                 } catch (Exception e) {
                     log.warn("Access Token 블랙리스트 실패: userId={}", userId, e);
                 }

--- a/src/main/java/com/proovy/global/config/SwaggerConfig.java
+++ b/src/main/java/com/proovy/global/config/SwaggerConfig.java
@@ -11,6 +11,10 @@ import io.swagger.v3.oas.models.servers.Server;
 import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.RouterFunctions;
+import org.springframework.web.servlet.function.ServerResponse;
 
 import java.util.List;
 
@@ -71,5 +75,36 @@ public class SwaggerConfig {
                 .filter(id -> id != null)
                 .findFirst()
                 .orElse("");
+    }
+
+    @Bean
+    public RouterFunction<ServerResponse> customSwaggerInitializer() {
+        return RouterFunctions.route()
+                .GET("/swagger-ui/swagger-initializer.js", request ->
+                        ServerResponse.ok()
+                                .contentType(MediaType.valueOf("text/javascript"))
+                                .body("""
+                                        window.onload = function() {
+                                          window.ui = SwaggerUIBundle({
+                                            configUrl: '/v3/api-docs/swagger-config',
+                                            dom_id: '#swagger-ui',
+                                            deepLinking: true,
+                                            presets: [
+                                              SwaggerUIBundle.presets.apis,
+                                              SwaggerUIStandalonePreset
+                                            ],
+                                            plugins: [
+                                              SwaggerUIBundle.plugins.DownloadUrl
+                                            ],
+                                            layout: "StandaloneLayout",
+                                            operationsSorter: function(a, b) {
+                                              var aId = a.get("operation").get("operationId") || "";
+                                              var bId = b.get("operation").get("operationId") || "";
+                                              return aId.localeCompare(bId);
+                                            }
+                                          });
+                                        };
+                                        """))
+                .build();
     }
 }

--- a/src/main/java/com/proovy/global/response/ErrorCode.java
+++ b/src/main/java/com/proovy/global/response/ErrorCode.java
@@ -28,7 +28,8 @@ public enum ErrorCode {
     AUTH5022("AUTH5022", "네이버 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     AUTH5023("AUTH5023", "구글 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
-            // User
+    // User
+    USER4004("USER4004", "활성화된 구독이 있습니다. 구독 취소 후 탈퇴해주세요.", HttpStatus.BAD_REQUEST),
     USER4041("USER4041", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     USER4091("USER4091", "이미 존재하는 사용자입니다.", HttpStatus.CONFLICT),
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #40 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- Proovy 서비스 회원 탈퇴(계정 영구 삭제) API 구현
- `DELETE /api/users/me` 엔드포인트 추가
- 활성 구독(FREE 제외)이 존재할 경우 탈퇴 차단 로직 구현
- 사용자 탈퇴 시 연관 데이터 정리
  - S3 업로드 파일 삭제
  - 노트, 자산, 구독 정보 DB 삭제
- 탈퇴 완료 시 `deletedAt` 반환하도록 Response DTO 구성
- 사용자 탈퇴 관련 ErrorCode 추가 (`USER4004`)
- Swagger 문서 작성 및 테스트 시나리오 정리

## 📸 스크린샷

Swagger 문서에서 카카오 로그인 -> 응답으로 나온 accessToken을 Authorize에 등록해줍니다.

<img width="948" height="171" alt="스크린샷 2026-01-30 133646" src="https://github.com/user-attachments/assets/8b7d402b-2b8e-4266-a69c-0cbad41a9de3" />

회원탈퇴가 잘 진행되는지 확인하기 위해 user_id 5번으로 카카오 계정을 등록해주었습니다. (phone은 컬럼을 삭제해서 현재 null로 표시됨)

<img width="804" height="289" alt="스크린샷 2026-01-30 133700" src="https://github.com/user-attachments/assets/58dc5cab-a823-4740-810b-88ea4cb28403" />

<img width="812" height="236" alt="스크린샷 2026-01-30 133717" src="https://github.com/user-attachments/assets/5295d24f-36ad-4495-a9a4-6d94ae14e8f1" />

Swagger에서 실행을 해주면 회원탈퇴 응답이 잘 오는걸 확인할 수 있습니다.
DB에서 다시 select * from users; 를 해주면


<img width="947" height="544" alt="스크린샷 2026-01-30 133730" src="https://github.com/user-attachments/assets/ff645217-67c4-4bc7-8840-e9421480b629" />

user_id 5번이 깔끔하게 삭제가 되었습니다!!

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (Swagger)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 활성 구독(FREE 제외) 이 존재할 경우 회원 탈퇴가 불가능하도록 정책을 적용했습니다.
- 사용자 탈퇴 시 데이터는 즉시 삭제되며 복구가 불가능합니다.
- S3 파일 삭제 실패 시에도 전체 트랜잭션이 롤백되지 않도록 예외를 로깅 처리했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 계정 영구 삭제 API 추가(/api/users/me) — 삭제 완료 시 삭제 시각(deletedAt) 반환

* **동작 변경 / 정리**
  * 계정 삭제 시 자산·노트·구독 플랜 등 관련 데이터 일괄 삭제 및 외부 저장소(S3) 정리 시도
  * 삭제 후 액세스/리프레시 토큰 무효화(블랙리스트) 처리 추가

* **오류 코드**
  * 활성화된 구독이 있으면 계정 삭제를 차단하는 신규 오류 코드 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->