### PR TITLE
[Refactor] Google OAuth redirect-uri 서버 설정 고정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,14 +16,42 @@ S3_BUCKET=
 # ===============================
 # Database (PostgreSQL)
 # ===============================
-DB_URL=jdbc:postgresql://localhost:5432/proovy
-DB_USERNAME=proovy_user
-DB_PASSWORD=your_password_here
+DB_HOST=
+DB_PORT=
+DB_NAME=
+DB_USERNAME=
+DB_PASSWORD=
 
 # ===============================
 # Redis (세션 / 캐시 / 토큰)
 # ===============================
-REDIS_HOST=localhost
-REDIS_PORT=6379
-REDIS_PASSWORD=your_password_here
-REDIS_DATABASE=0
+REDIS_HOST=
+REDIS_PORT=
+REDIS_PASSWORD=
+REDIS_DATABASE=
+
+# ===============================
+# KAKAO Login
+# ===============================
+KAKAO_CLIENT_ID=
+KAKAO_CLIENT_SECRET=
+KAKAO_REDIRECT_URI=
+
+# ===============================
+# NAVER Login
+# ===============================
+NAVER_CLIENT_ID=
+NAVER_CLIENT_SECRET=
+NAVER_REDIRECT_URI=
+
+# ===============================
+# GOOGLE Login
+# ===============================
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=
+
+# ===============================
+# JWT Secret
+# ===============================
+JWT_SECRET=

--- a/src/main/java/com/proovy/domain/asset/repository/AssetRepository.java
+++ b/src/main/java/com/proovy/domain/asset/repository/AssetRepository.java
@@ -49,4 +49,9 @@ public interface AssetRepository extends JpaRepository<Asset, Long> {
      * OCR 상태가 특정 값이고 updatedAt이 특정 시각 이전인 자산 목록 조회 (타임아웃 처리용)
      */
     List<Asset> findByOcrStatusAndUpdatedAtBefore(Asset.OcrStatus ocrStatus, LocalDateTime threshold);
+
+    /**
+     * 특정 사용자의 모든 자산 삭제 (회원 탈퇴용)
+     */
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/proovy/domain/auth/dto/request/GoogleLoginRequest.java
+++ b/src/main/java/com/proovy/domain/auth/dto/request/GoogleLoginRequest.java
@@ -2,10 +2,11 @@ package com.proovy.domain.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 
+/**
+ * 구글 로그인 요청
+ * redirectUri는 서버 설정값 사용
+ */
 public record GoogleLoginRequest(
         @NotBlank(message = "인증 코드는 필수입니다")
-        String authorizationCode,
-
-        @NotBlank(message = "Redirect URI는 필수입니다")
-        String redirectUri
+        String authorizationCode
 ) {}

--- a/src/main/java/com/proovy/domain/auth/provider/GoogleOAuthClient.java
+++ b/src/main/java/com/proovy/domain/auth/provider/GoogleOAuthClient.java
@@ -32,6 +32,9 @@ public class GoogleOAuthClient {
     @Value("${oauth.google.client-secret}")
     private String clientSecret;
 
+    @Value("${oauth.google.redirect-uri}")
+    private String redirectUri;
+
     @Value("${oauth.google.token-uri}")
     private String tokenUri;
 
@@ -40,8 +43,9 @@ public class GoogleOAuthClient {
 
     /**
      * 인가 코드로 액세스 토큰 발급
+     * redirectUri는 서버 설정값 사용
      */
-    public GoogleTokenResponse getAccessToken(String authorizationCode, String redirectUri) {
+    public GoogleTokenResponse getAccessToken(String authorizationCode) {
         // 구글 인가 코드는 '/'를 포함하므로 URL 디코딩 필요 (4%2F... -> 4/...)
         String decodedCode = URLDecoder.decode(authorizationCode, StandardCharsets.UTF_8);
 

--- a/src/main/java/com/proovy/domain/auth/service/AuthService.java
+++ b/src/main/java/com/proovy/domain/auth/service/AuthService.java
@@ -179,8 +179,7 @@ public class AuthService {
     public LoginResponse googleLogin(GoogleLoginRequest request) {
         // 1. 구글 액세스 토큰 발급
         GoogleTokenResponse googleToken = googleClient.getAccessToken(
-                request.authorizationCode(),
-                request.redirectUri()
+                request.authorizationCode()
         );
         log.info("구글 토큰 발급 성공, expires_in: {}", googleToken.expiresIn());
 

--- a/src/main/java/com/proovy/domain/note/repository/NoteRepository.java
+++ b/src/main/java/com/proovy/domain/note/repository/NoteRepository.java
@@ -2,6 +2,7 @@ package com.proovy.domain.note.repository;
 
 import com.proovy.domain.note.entity.Note;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,4 +16,11 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
            "AND LOWER(n.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
            "ORDER BY n.createdAt DESC")
     List<Note> searchByTitleKeyword(@Param("userId") Long userId, @Param("keyword") String keyword);
+
+    /**
+     * 특정 사용자의 모든 노트 삭제 (회원 탈퇴용)
+     */
+    @Modifying
+    @Query("DELETE FROM Note n WHERE n.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/proovy/domain/note/repository/NoteRepository.java
+++ b/src/main/java/com/proovy/domain/note/repository/NoteRepository.java
@@ -24,7 +24,7 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
     /**
      * 특정 사용자의 모든 노트 삭제 (회원 탈퇴용)
      */
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Note n WHERE n.user.id = :userId")
     void deleteAllByUserId(@Param("userId") Long userId);
 

--- a/src/main/java/com/proovy/domain/user/controller/UserController.java
+++ b/src/main/java/com/proovy/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.proovy.domain.user.controller;
 
+import com.proovy.domain.user.dto.response.DeleteUserResponse;
 import com.proovy.domain.user.dto.response.MyProfileResponse;
 import com.proovy.domain.user.dto.response.SubscriptionResponse;
 import com.proovy.domain.user.service.SubscriptionService;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -75,5 +77,24 @@ public class UserController {
     ) {
         SubscriptionResponse response = subscriptionService.getSubscription(userPrincipal.getUserId());
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/me")
+    @Operation(
+            operationId = "04_deleteUser",
+            summary = "회원 탈퇴",
+            description = "현재 로그인한 사용자의 계정을 영구 삭제합니다. 모든 노트, 파일, 구독 정보가 삭제됩니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "탈퇴 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "활성 구독 존재 (USER4004)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 (AUTH4013)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자 없음 (USER4041)")
+    })
+    public ResponseEntity<ApiResponse<DeleteUserResponse>> deleteUser(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal.getUserId();
+        DeleteUserResponse response = userService.deleteUser(userId);
+        return ResponseEntity.ok(ApiResponse.success("회원 탈퇴가 완료되었습니다.", response));
     }
 }

--- a/src/main/java/com/proovy/domain/user/controller/UserController.java
+++ b/src/main/java/com/proovy/domain/user/controller/UserController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -91,10 +92,20 @@ public class UserController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자 없음 (USER4041)")
     })
     public ResponseEntity<ApiResponse<DeleteUserResponse>> deleteUser(
-            @AuthenticationPrincipal UserPrincipal userPrincipal
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            HttpServletRequest request
     ) {
         Long userId = userPrincipal.getUserId();
-        DeleteUserResponse response = userService.deleteUser(userId);
+        String accessToken = extractAccessToken(request);
+        DeleteUserResponse response = userService.deleteUser(userId, accessToken);
         return ResponseEntity.ok(ApiResponse.success("회원 탈퇴가 완료되었습니다.", response));
+    }
+
+    private String extractAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
     }
 }

--- a/src/main/java/com/proovy/domain/user/controller/UserController.java
+++ b/src/main/java/com/proovy/domain/user/controller/UserController.java
@@ -81,7 +81,7 @@ public class UserController {
 
     @DeleteMapping("/me")
     @Operation(
-            operationId = "04_deleteUser",
+            operationId = "03_deleteUser",
             summary = "회원 탈퇴",
             description = "현재 로그인한 사용자의 계정을 영구 삭제합니다. 모든 노트, 파일, 구독 정보가 삭제됩니다.")
     @ApiResponses({

--- a/src/main/java/com/proovy/domain/user/dto/response/DeleteUserResponse.java
+++ b/src/main/java/com/proovy/domain/user/dto/response/DeleteUserResponse.java
@@ -1,0 +1,14 @@
+package com.proovy.domain.user.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record DeleteUserResponse(
+        String deletedAt
+) {
+    public static DeleteUserResponse of(String deletedAt) {
+        return DeleteUserResponse.builder()
+                .deletedAt(deletedAt)
+                .build();
+    }
+}

--- a/src/main/java/com/proovy/domain/user/repository/UserPlanRepository.java
+++ b/src/main/java/com/proovy/domain/user/repository/UserPlanRepository.java
@@ -3,6 +3,7 @@ package com.proovy.domain.user.repository;
 import com.proovy.domain.user.entity.PlanType;
 import com.proovy.domain.user.entity.UserPlan;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,4 +16,11 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, Long> {
 
     @Query("SELECT up.planType FROM UserPlan up WHERE up.user.id = :userId AND up.isActive = true ORDER BY up.startedAt DESC LIMIT 1")
     Optional<PlanType> findActivePlanTypeByUserId(@Param("userId") Long userId);
+
+    /**
+     * 특정 사용자의 모든 플랜 삭제 (회원 탈퇴용)
+     */
+    @Modifying
+    @Query("DELETE FROM UserPlan up WHERE up.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/proovy/domain/user/repository/UserPlanRepository.java
+++ b/src/main/java/com/proovy/domain/user/repository/UserPlanRepository.java
@@ -20,7 +20,7 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, Long> {
     /**
      * 특정 사용자의 모든 플랜 삭제 (회원 탈퇴용)
      */
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM UserPlan up WHERE up.user.id = :userId")
     void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/proovy/domain/user/service/UserService.java
+++ b/src/main/java/com/proovy/domain/user/service/UserService.java
@@ -160,10 +160,16 @@ public class UserService {
     }
 
     private void deleteUserData(Long userId) {
-        // S3 키를 먼저 수집
-        List<String> s3Keys = assetRepository.findAllByUserId(userId).stream()
-                .map(asset -> asset.getS3Key())
-                .collect(Collectors.toList());
+        // S3 키를 먼저 수집 (원본 + 썸네일)
+        List<String> s3Keys = new java.util.ArrayList<>();
+        assetRepository.findAllByUserId(userId).forEach(asset -> {
+            if (asset.getS3Key() != null) {
+                s3Keys.add(asset.getS3Key());
+            }
+            if (asset.getThumbnailS3Key() != null) {
+                s3Keys.add(asset.getThumbnailS3Key());
+            }
+        });
 
         // DB 데이터 삭제
         assetRepository.deleteAllByUserId(userId);

--- a/src/main/java/com/proovy/domain/user/service/UserService.java
+++ b/src/main/java/com/proovy/domain/user/service/UserService.java
@@ -149,8 +149,14 @@ public class UserService {
         userRepository.delete(user);
 
         // 5. 토큰 무효화
-        accessTokenBlacklistService.blacklist(accessToken, userId);
         refreshTokenRepository.deleteByUserId(userId);
+        // Access Token 블랙리스트는 Redis 기반이므로 커밋 이후 실행
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                accessTokenBlacklistService.blacklist(accessToken, userId);
+            }
+        });
 
         log.info("사용자 탈퇴 완료: userId={}", userId);
 

--- a/src/main/java/com/proovy/domain/user/service/UserService.java
+++ b/src/main/java/com/proovy/domain/user/service/UserService.java
@@ -1,13 +1,17 @@
 package com.proovy.domain.user.service;
 
 import com.proovy.domain.asset.repository.AssetRepository;
+import com.proovy.domain.note.repository.NoteRepository;
+import com.proovy.domain.user.dto.response.DeleteUserResponse;
 import com.proovy.domain.user.dto.response.MyProfileResponse;
 import com.proovy.domain.user.dto.response.MyProfileResponse.*;
 import com.proovy.domain.user.entity.PlanType;
 import com.proovy.domain.user.entity.User;
+import com.proovy.domain.user.entity.UserPlan;
 import com.proovy.domain.user.repository.UserPlanRepository;
 import com.proovy.domain.user.repository.UserRepository;
 import com.proovy.global.exception.BusinessException;
+import com.proovy.global.infra.s3.S3Service;
 import com.proovy.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -27,6 +32,8 @@ public class UserService {
     private final UserRepository userRepository;
     private final UserPlanRepository userPlanRepository;
     private final AssetRepository assetRepository;
+    private final NoteRepository noteRepository;
+    private final S3Service s3Service;
 
     /**
      * 내 프로필 조회
@@ -110,5 +117,49 @@ public class UserService {
     private String formatDate(LocalDateTime dateTime) {
         if (dateTime == null) return null;
         return dateTime.toLocalDate().format(DateTimeFormatter.ISO_LOCAL_DATE);
+    }
+
+    /**
+     * 회원 탈퇴
+     */
+    @Transactional
+    public DeleteUserResponse deleteUser(Long userId) {
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER4041));
+
+        // 2. 활성 구독 확인 (FREE가 아닌 플랜이 활성 상태면 탈퇴 불가)
+        Optional<UserPlan> activePlan = userPlanRepository.findActiveByUserId(userId);
+        if (activePlan.isPresent() && activePlan.get().getPlanType() != PlanType.FREE) {
+            throw new BusinessException(ErrorCode.USER4004);
+        }
+
+        // 3. 사용자 관련 데이터 삭제
+        deleteUserData(userId);
+
+        // 4. 사용자 삭제
+        userRepository.delete(user);
+
+        log.info("사용자 탈퇴 완료: userId={}", userId);
+
+        return DeleteUserResponse.of(
+                LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        );
+    }
+
+    private void deleteUserData(Long userId) {
+        // S3 파일 삭제
+        assetRepository.findAllByUserId(userId).forEach(asset -> {
+            try {
+                s3Service.deleteFile(asset.getS3Key());
+            } catch (Exception e) {
+                log.warn("S3 파일 삭제 실패: s3Key={}", asset.getS3Key(), e);
+            }
+        });
+
+        // DB 데이터 삭제
+        assetRepository.deleteAllByUserId(userId);
+        noteRepository.deleteAllByUserId(userId);
+        userPlanRepository.deleteAllByUserId(userId);
     }
 }

--- a/src/main/java/com/proovy/domain/user/service/UserService.java
+++ b/src/main/java/com/proovy/domain/user/service/UserService.java
@@ -154,7 +154,11 @@ public class UserService {
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                accessTokenBlacklistService.blacklist(accessToken, userId);
+                try {
+                    accessTokenBlacklistService.blacklist(accessToken, userId);
+                } catch (Exception e) {
+                    log.warn("Access Token 블랙리스트 실패: userId={}", userId, e);
+                }
             }
         });
 

--- a/src/main/java/com/proovy/domain/user/service/UserService.java
+++ b/src/main/java/com/proovy/domain/user/service/UserService.java
@@ -155,7 +155,9 @@ public class UserService {
             @Override
             public void afterCommit() {
                 try {
-                    accessTokenBlacklistService.blacklist(accessToken, userId);
+                    if (accessToken != null) {
+                        accessTokenBlacklistService.blacklist(accessToken, userId);
+                    }
                 } catch (Exception e) {
                     log.warn("Access Token 블랙리스트 실패: userId={}", userId, e);
                 }

--- a/src/main/java/com/proovy/global/config/SwaggerConfig.java
+++ b/src/main/java/com/proovy/global/config/SwaggerConfig.java
@@ -11,6 +11,10 @@ import io.swagger.v3.oas.models.servers.Server;
 import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.RouterFunctions;
+import org.springframework.web.servlet.function.ServerResponse;
 
 import java.util.List;
 
@@ -71,5 +75,36 @@ public class SwaggerConfig {
                 .filter(id -> id != null)
                 .findFirst()
                 .orElse("");
+    }
+
+    @Bean
+    public RouterFunction<ServerResponse> customSwaggerInitializer() {
+        return RouterFunctions.route()
+                .GET("/swagger-ui/swagger-initializer.js", request ->
+                        ServerResponse.ok()
+                                .contentType(MediaType.valueOf("text/javascript"))
+                                .body("""
+                                        window.onload = function() {
+                                          window.ui = SwaggerUIBundle({
+                                            configUrl: '/v3/api-docs/swagger-config',
+                                            dom_id: '#swagger-ui',
+                                            deepLinking: true,
+                                            presets: [
+                                              SwaggerUIBundle.presets.apis,
+                                              SwaggerUIStandalonePreset
+                                            ],
+                                            plugins: [
+                                              SwaggerUIBundle.plugins.DownloadUrl
+                                            ],
+                                            layout: "StandaloneLayout",
+                                            operationsSorter: function(a, b) {
+                                              var aId = a.get("operation").get("operationId") || "";
+                                              var bId = b.get("operation").get("operationId") || "";
+                                              return aId.localeCompare(bId);
+                                            }
+                                          });
+                                        };
+                                        """))
+                .build();
     }
 }

--- a/src/main/java/com/proovy/global/response/ErrorCode.java
+++ b/src/main/java/com/proovy/global/response/ErrorCode.java
@@ -28,7 +28,8 @@ public enum ErrorCode {
     AUTH5022("AUTH5022", "네이버 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     AUTH5023("AUTH5023", "구글 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
-            // User
+    // User
+    USER4004("USER4004", "활성화된 구독이 있습니다. 구독 취소 후 탈퇴해주세요.", HttpStatus.BAD_REQUEST),
     USER4041("USER4041", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     USER4091("USER4091", "이미 존재하는 사용자입니다.", HttpStatus.CONFLICT),
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -72,6 +72,7 @@ oauth:
   google:
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
+    redirect-uri: ${GOOGLE_REDIRECT_URI:http://localhost:3000/oauth/google/callback}
     # 구글 API 엔드포인트
     token-uri: https://oauth2.googleapis.com/token
     user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #62 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- GoogleLoginRequest에서 redirectUri 필드 제거
- GoogleOAuthClient에서 redirect-uri를 서버 설정 값으로 고정
- AuthService에서 redirectUri 전달 로직 제거
- application.yaml에 oauth.google.redirect-uri 설정 추가
- .env.example에 GOOGLE_REDIRECT_URI 항목 추가
- Google OAuth 흐름을 네이버 OAuth와 동일한 구조로 통일

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (env 예시)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 프론트엔드는 authorizationCode만 전달


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 사용자 계정 영구 삭제 기능 추가. 활성 구독 보유 시 삭제 제한.
  * 계정 삭제 시 모든 관련 데이터 자동 정리 (노트, 자산, 플랜).

* **설정**
  * Google OAuth 및 소셜 로그인 환경변수 구성 업데이트.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->