### PR TITLE
[Feat] AWS RDS, Redis 연동 및 EC2 서버 배포

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,8 +27,6 @@ DB_PASSWORD=
 # ===============================
 REDIS_HOST=
 REDIS_PORT=
-REDIS_PASSWORD=
-REDIS_DATABASE=
 
 # ===============================
 # KAKAO Login

--- a/src/main/java/com/proovy/domain/auth/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/proovy/domain/auth/dto/request/KakaoLoginRequest.java
@@ -4,8 +4,5 @@ import jakarta.validation.constraints.NotBlank;
 
 public record KakaoLoginRequest(
         @NotBlank(message = "인증 코드는 필수입니다")
-        String authorizationCode,
-
-        @NotBlank(message = "Redirect URI는 필수입니다")
-        String redirectUri
+        String authorizationCode
 ) {}

--- a/src/main/java/com/proovy/domain/auth/provider/KakaoOAuthClient.java
+++ b/src/main/java/com/proovy/domain/auth/provider/KakaoOAuthClient.java
@@ -32,13 +32,16 @@ public class KakaoOAuthClient {
     @Value("${oauth.kakao.token-uri}")
     private String tokenUri;
 
+    @Value("${oauth.kakao.redirect-uri}")
+    private String redirectUri;
+
     @Value("${oauth.kakao.user-info-uri}")
     private String userInfoUri;
 
     /**
      * 인가 코드로 액세스 토큰 발급
      */
-    public KakaoTokenResponse getAccessToken(String authorizationCode, String redirectUri) {
+    public KakaoTokenResponse getAccessToken(String authorizationCode) {
         try {
             return webClient.post()
                     .uri(tokenUri)

--- a/src/main/java/com/proovy/domain/auth/service/AuthService.java
+++ b/src/main/java/com/proovy/domain/auth/service/AuthService.java
@@ -63,8 +63,7 @@ public class AuthService {
     public LoginResponse kakaoLogin(KakaoLoginRequest request) {
         // 1. 카카오 액세스 토큰 발급
         KakaoTokenResponse kakaoToken = kakaoClient.getAccessToken(
-                request.authorizationCode(),
-                request.redirectUri()
+                request.authorizationCode()
         );
         log.info("카카오 토큰 발급 성공, expires_in: {}", kakaoToken.expiresIn());
 

--- a/src/main/java/com/proovy/global/config/SwaggerConfig.java
+++ b/src/main/java/com/proovy/global/config/SwaggerConfig.java
@@ -33,12 +33,7 @@ public class SwaggerConfig {
                         .description("Proovy 백엔드 API 명세서")
                         .version("v1.0.0"))
                 .servers(List.of(
-                        new Server()
-                                .url("http://localhost:8080")
-                                .description("로컬 개발 서버"),
-                        new Server()
-                                .url("https://api.proovy.com")
-                                .description("프로덕션 서버")
+                        new Server().url("/")
                 ))
                 .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
                 .components(new Components()

--- a/src/main/java/com/proovy/global/config/SwaggerConfig.java
+++ b/src/main/java/com/proovy/global/config/SwaggerConfig.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.servers.Server;
+
 import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,7 +16,6 @@ import org.springframework.web.servlet.function.RouterFunction;
 import org.springframework.web.servlet.function.RouterFunctions;
 import org.springframework.web.servlet.function.ServerResponse;
 
-import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
@@ -32,9 +31,6 @@ public class SwaggerConfig {
                         .title("Proovy API")
                         .description("Proovy 백엔드 API 명세서")
                         .version("v1.0.0"))
-                .servers(List.of(
-                        new Server().url("/")
-                ))
                 .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
                 .components(new Components()
                         .addSecuritySchemes(securitySchemeName,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,6 +25,7 @@ springdoc:
 
 server:
   port: 8080
+  forward-headers-strategy: framework
 
 # ===============================
 # AWS 설정

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -49,7 +49,7 @@ oauth:
   kakao:
     client-id: ${KAKAO_CLIENT_ID}
     client-secret: ${KAKAO_CLIENT_SECRET}
-    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:3000/oauth/kakao/callback}
+    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:5173/oauth/kakao/callback}
     # 카카오 API 엔드포인트
     auth-url: https://kauth.kakao.com
     api-url: https://kapi.kakao.com
@@ -62,7 +62,7 @@ oauth:
     client-id: ${NAVER_CLIENT_ID}
     client-secret: ${NAVER_CLIENT_SECRET}
     # redirectUri는 서버에서 고정 (보안상 Request Body에서 받지 않음)
-    redirect-uri: ${NAVER_REDIRECT_URI:http://localhost:3000/oauth/naver/callback}
+    redirect-uri: ${NAVER_REDIRECT_URI:http://localhost:5173/oauth/naver/callback}
     # 네이버 API 엔드포인트
     authorize-uri: https://nid.naver.com/oauth2.0/authorize
     token-uri: https://nid.naver.com/oauth2.0/token
@@ -73,7 +73,7 @@ oauth:
   google:
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
-    redirect-uri: ${GOOGLE_REDIRECT_URI:http://localhost:3000/oauth/google/callback}
+    redirect-uri: ${GOOGLE_REDIRECT_URI:http://localhost:5173/oauth/google/callback}
     # 구글 API 엔드포인트
     token-uri: https://oauth2.googleapis.com/token
     user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #64 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- AWS RDS(PostgreSQL) 연동 및 `proovy` 데이터베이스 연결
- AWS ElastiCache Redis(Valkey) 연동 및 캐시 연결 확인
- EC2 환경 변수(.env) 기반 prod 설정 구성
- EC2 보안 그룹에 8080 포트 개방
- Spring Boot JAR 빌드 후 EC2 배포 및 실행
- Swagger UI 외부 접근 가능하도록 설정
- `/v3/api-docs` 기준 OpenAPI 서버 설정 점검

## 📸 스크린샷

<img width="896" height="863" alt="image" src="https://github.com/user-attachments/assets/abb780d4-994b-4e40-840b-e8c8a587976b" />

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 로컬 및 EC2 환경에서 서버 정상 기동 확인
- [x] RDS / Redis 연결 로그 확인
- [x] Swagger UI 외부 접속 확인
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 초기 배포 시 테이블 생성을 위해 `ddl-auto=update`로 1회 실행
- 이후 운영 모드에서는 `ddl-auto=validate` 사용 예정
- 도메인 및 HTTPS 연결은 후속 작업으로 분리 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 환경 설정 예제에서 Redis 관련 변수(비밀번호·데이터베이스) 제거
  * API 문서의 서버 정의(서버 목록/호스트) 삭제 및 간소화
  * 서버 구성에 forwarded headers 처리 방식(framework) 추가
  * OAuth 기본 리디렉션 URI 호스트/포트 기본값을 로컬 개발 포트(5173)로 업데이트
  * 카카오 로그인 요청에서 리디렉션 URI 전달을 제거하여 클라이언트 내부 설정으로 이동

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->