### PR TITLE
[Refactor] 프론트에서 code 검증 후 백엔드에서 한 번 더 검증하는 중복 수정

### DIFF
--- a/src/main/java/com/proovy/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/proovy/domain/auth/controller/AuthController.java
@@ -73,10 +73,10 @@ public class AuthController {
     @Operation(
             operationId = "03_naverLogin",
             summary = "네이버 소셜 로그인",
-            description = "네이버 인가 코드와 state로 로그인합니다. 신규 유저는 회원가입 토큰을 반환합니다.")
+            description = "네이버 인가 코드로 로그인합니다. state는 프론트엔드에서 검증됩니다. 신규 유저는 회원가입 토큰을 반환합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "state 불일치 (AUTH4002), 유효하지 않은 인증 코드 (AUTH4011)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 인증 코드 (AUTH4011)"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "네이버 서버 오류 (AUTH5022)")
     })
     public ResponseEntity<ApiResponse<LoginResponse>> naverLogin(

--- a/src/main/java/com/proovy/domain/auth/dto/request/NaverLoginRequest.java
+++ b/src/main/java/com/proovy/domain/auth/dto/request/NaverLoginRequest.java
@@ -5,11 +5,9 @@ import jakarta.validation.constraints.NotBlank;
 /**
  * 네이버 로그인 요청
  * redirectUri는 서버 설정값 사용
+ * state는 프론트엔드에서 검증됨 (CSRF 방지)
  */
 public record NaverLoginRequest(
         @NotBlank(message = "인증 코드는 필수입니다")
-        String code,
-
-        @NotBlank(message = "state는 필수입니다")
-        String state
+        String code
 ) {}

--- a/src/main/java/com/proovy/domain/auth/provider/NaverOAuthClient.java
+++ b/src/main/java/com/proovy/domain/auth/provider/NaverOAuthClient.java
@@ -54,8 +54,9 @@ public class NaverOAuthClient {
     /**
      * 인가 코드로 액세스 토큰 발급
      * redirectUri는 서버 설정값
+     * state는 프론트엔드에서 이미 검증됨
      */
-    public NaverTokenResponse getAccessToken(String code, String state) {
+    public NaverTokenResponse getAccessToken(String code) {
         try {
             NaverTokenResponse response = webClient.post()
                     .uri(tokenUri)
@@ -64,8 +65,7 @@ public class NaverOAuthClient {
                             .with("client_id", clientId)
                             .with("client_secret", clientSecret)
                             .with("redirect_uri", redirectUri)
-                            .with("code", code)
-                            .with("state", state))
+                            .with("code", code))
                     .retrieve()
                     .onStatus(HttpStatusCode::is4xxClientError, res ->
                             res.bodyToMono(String.class)

--- a/src/main/java/com/proovy/domain/auth/service/AuthService.java
+++ b/src/main/java/com/proovy/domain/auth/service/AuthService.java
@@ -125,34 +125,24 @@ public class AuthService {
 
     /**
      * 네이버 로그인 처리
+     * state 검증은 프론트엔드에서 수행됨 (CSRF 방지)
      */
     @Transactional
     public LoginResponse naverLogin(@Valid NaverLoginRequest request) {
-        // 1. state 검증
-        String redisKey = "naver_state:" + request.state();
-        Boolean deleted = redisTemplate.delete(redisKey);
-        if (deleted == null || !deleted) {
-            log.warn("네이버 state 검증 실패 (존재하지 않거나 이미 사용됨)");
-            throw new BusinessException(ErrorCode.AUTH4002);
-        }
-
-        // 2. 네이버 액세스 토큰 발급
-        NaverTokenResponse naverToken = naverClient.getAccessToken(
-                request.code(),
-                request.state()
-        );
+        // 1. 네이버 액세스 토큰 발급
+        NaverTokenResponse naverToken = naverClient.getAccessToken(request.code());
         log.info("네이버 토큰 발급 성공, expires_in: {}", naverToken.expiresIn());
 
-        // 3. 네이버 사용자 정보 조회
+        // 2. 네이버 사용자 정보 조회
         NaverUserResponse naverUser = naverClient.getUserInfo(naverToken.accessToken());
         log.info("네이버 사용자 정보 조회 성공, id: {}", naverUser.response().id());
 
-        // 4. 기존 유저 조회
+        // 3. 기존 유저 조회
         String providerUserId = naverUser.response().id();
         Optional<User> existingUser = userRepository
                 .findByProviderAndProviderUserId(OAuthProvider.NAVER, providerUserId);
 
-        // 5. 분기 처리
+        // 4. 분기 처리
         if (existingUser.isPresent()) {
             // 기존 유저: JWT 발급
             User user = existingUser.get();


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #77 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 네이버 OAuth 로그인 시 state 중복 검증 구조 제거
- state 검증 책임을 프론트엔드로 일원화하도록 백엔드 로직 수정
- NaverLoginRequest에서 state 필드 제거 (code만 수신)
- AuthService에서 Redis 기반 state 검증 로직 제거
- NaverOAuthClient.getAccessToken 시그니처 변경 (code만 사용)
- 네이버 토큰 요청 시 state 파라미터 제거
- AuthController Swagger 설명 및 에러 응답 문구 수정

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- OAuth state는 CSRF 방지 목적이므로 프론트엔드에서 sessionStorage 기반으로 검증합니다.
- 서버는 authorization code 기반 토큰 교환 및 사용자 인증 처리만 담당합니다.
- 기존 Redis state 저장 구조는 제거되었습니다.
