### PR TITLE
[Feat] 기능별 크레딧 소모 비용 조회 API

### DIFF
--- a/src/main/java/com/proovy/domain/credit/controller/CreditController.java
+++ b/src/main/java/com/proovy/domain/credit/controller/CreditController.java
@@ -1,6 +1,8 @@
 package com.proovy.domain.credit.controller;
 
+import com.proovy.domain.credit.dto.response.CreditCostResponse;
 import com.proovy.domain.credit.dto.response.CreditHistoryResponse;
+import com.proovy.domain.credit.service.CreditCostService;
 import com.proovy.domain.credit.service.CreditHistoryService;
 import com.proovy.global.response.ApiResponse;
 import com.proovy.global.security.UserPrincipal;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CreditController {
 
     private final CreditHistoryService creditHistoryService;
+    private final CreditCostService creditCostService;
 
     @GetMapping("/history")
     @Operation(
@@ -83,6 +86,29 @@ public class CreditController {
                 userId, page, size, changeType, creditType, startDate, endDate
         );
 
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/costs")
+    @Operation(
+            operationId = "02_getCreditCosts",
+            summary = "크레딧 비용 정책 조회",
+            description = "각 기능(OCR, 코드 실행, AI 질의 등)의 현재 적용 중인 크레딧 소모 비용을 조회합니다. 인증이 필요하지 않습니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = CreditCostResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(schema = @Schema(example = "{\"isSuccess\":false,\"code\":\"SERVER5001\",\"message\":\"서버 오류가 발생했습니다.\"}"))
+            )
+    })
+    public ResponseEntity<ApiResponse<CreditCostResponse>> getCreditCosts() {
+        CreditCostResponse response = creditCostService.getCreditCosts();
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/proovy/domain/credit/controller/CreditController.java
+++ b/src/main/java/com/proovy/domain/credit/controller/CreditController.java
@@ -93,13 +93,18 @@ public class CreditController {
     @Operation(
             operationId = "02_getCreditCosts",
             summary = "크레딧 비용 정책 조회",
-            description = "각 기능(OCR, 코드 실행, AI 질의 등)의 현재 적용 중인 크레딧 소모 비용을 조회합니다. 인증이 필요하지 않습니다."
+            description = "각 기능(OCR, 코드 실행, AI 질의 등)의 현재 적용 중인 크레딧 소모 비용을 조회합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "200",
                     description = "조회 성공",
                     content = @Content(schema = @Schema(implementation = CreditCostResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(schema = @Schema(example = "{\"isSuccess\":false,\"code\":\"AUTH4013\",\"message\":\"유효하지 않은 토큰입니다.\"}"))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "500",

--- a/src/main/java/com/proovy/domain/credit/dto/response/CreditCostResponse.java
+++ b/src/main/java/com/proovy/domain/credit/dto/response/CreditCostResponse.java
@@ -28,7 +28,7 @@ public class CreditCostResponse {
         @Schema(description = "기능 설명", example = "OCR 텍스트 추출")
         private String description;
 
-        @Schema(description = "비용 (null인 경우 사용량 기반)", example = "10")
+        @Schema(description = "비용 (null인 경우 사용량 기반)", example = "10", nullable = true)
         private Integer costAmount;
 
         @Schema(description = "고정 비용 여부", example = "true")

--- a/src/main/java/com/proovy/domain/credit/dto/response/CreditCostResponse.java
+++ b/src/main/java/com/proovy/domain/credit/dto/response/CreditCostResponse.java
@@ -1,0 +1,37 @@
+package com.proovy.domain.credit.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "크레딧 비용 조회 응답")
+public class CreditCostResponse {
+
+    @Schema(description = "비용 정책 목록")
+    private List<CreditCostItemDto> costs;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "크레딧 비용 항목")
+    public static class CreditCostItemDto {
+
+        @Schema(description = "이벤트 타입", example = "OCR")
+        private String eventType;
+
+        @Schema(description = "기능 설명", example = "OCR 텍스트 추출")
+        private String description;
+
+        @Schema(description = "비용 (null인 경우 사용량 기반)", example = "10")
+        private Integer costAmount;
+
+        @Schema(description = "고정 비용 여부", example = "true")
+        private Boolean isFixed;
+    }
+}

--- a/src/main/java/com/proovy/domain/credit/service/CreditCostService.java
+++ b/src/main/java/com/proovy/domain/credit/service/CreditCostService.java
@@ -1,0 +1,57 @@
+package com.proovy.domain.credit.service;
+
+import com.proovy.domain.credit.dto.response.CreditCostResponse;
+import com.proovy.domain.credit.entity.CreditEventType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CreditCostService {
+
+    // TODO: DB에서 관리하도록 변경
+    private static final int OCR_COST = 10;
+    private static final int CODE_EXECUTION_COST = 5;
+
+    /**
+     * 크레딧 비용 정책 조회
+     * SPEND 타입 이벤트만 반환
+     */
+    public CreditCostResponse getCreditCosts() {
+        List<CreditCostResponse.CreditCostItemDto> costs = new ArrayList<>();
+
+        // OCR 비용
+        costs.add(CreditCostResponse.CreditCostItemDto.builder()
+                .eventType(CreditEventType.OCR.name())
+                .description(CreditEventType.OCR.getDescription())
+                .costAmount(OCR_COST)
+                .isFixed(true)
+                .build());
+
+        // 코드 실행 비용
+        costs.add(CreditCostResponse.CreditCostItemDto.builder()
+                .eventType(CreditEventType.CODE_EXECUTION.name())
+                .description(CreditEventType.CODE_EXECUTION.getDescription())
+                .costAmount(CODE_EXECUTION_COST)
+                .isFixed(true)
+                .build());
+
+        // LLM 질의 비용 (사용량 기반)
+        costs.add(CreditCostResponse.CreditCostItemDto.builder()
+                .eventType(CreditEventType.LLM_QUERY.name())
+                .description(CreditEventType.LLM_QUERY.getDescription() + " (사용량 기반)")
+                .costAmount(null)
+                .isFixed(false)
+                .build());
+
+        log.info("크레딧 비용 정책 조회 완료, 총 {}개 항목", costs.size());
+        return CreditCostResponse.builder()
+                .costs(costs)
+                .build();
+    }
+}

--- a/src/main/java/com/proovy/global/security/SecurityConfig.java
+++ b/src/main/java/com/proovy/global/security/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                         // 인증 없이 접근 가능
                         .requestMatchers("/api/auth/logout").authenticated()
                         .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/credits/costs").permitAll()
                         .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/health", "/actuator/health").permitAll()
                         // 나머지는 인증 필요

--- a/src/main/java/com/proovy/global/security/SecurityConfig.java
+++ b/src/main/java/com/proovy/global/security/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                         // 인증 없이 접근 가능
                         .requestMatchers("/api/auth/logout").authenticated()
                         .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/api/credits/costs").permitAll()
+                        .requestMatchers("/api/conversations", "/api/conversations/**").permitAll()
                         .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/health", "/actuator/health").permitAll()
                         // 나머지는 인증 필요


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #74 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 크레딧 비용 정책 조회 API 신규 추가
- GET /api/credits/costs 엔드포인트 구현
- CreditCostResponse DTO 생성
- CreditCostService 서비스 클래스 구현
- CreditController에 costs 조회 API 메서드 추가
- Swagger Operation / Response 스키마 문서화
- SPEND 타입 이벤트(OCR, CODE_EXECUTION, LLM_QUERY)만 비용 조회 대상으로 구성
- 고정 비용 / 사용량 기반 비용 구분 필드(isFixed) 포함

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 현재 비용 정책은 코드 상수로 관리하고 있습니다 (OCR=10, CODE_EXECUTION=5)
- LLM_QUERY는 사용량 기반 차감이므로 costAmount는 null로 반환됩니다
- 추후 DB 또는 application.yml 기반 설정으로 비용 정책 외부화 가능하도록 확장할 수 있습니다.
- 인증 없이 호출 가능한 공개 API로 설계했습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 크레딧 비용 정책 조회 API 추가 — OCR, 코드 실행(고정 비용) 및 LLM 쿼리(사용량 기반) 등 기능별 크레딧 비용 정책을 조회할 수 있는 공개 엔드포인트가 제공됩니다. 문서화된 응답으로 각 항목의 설명, 비용 정보(없을 수 있음) 및 고정 여부를 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->