### PR TITLE
[Feat] 난이도 기반 크레딧 사용/조회 API

### DIFF
--- a/src/main/java/com/proovy/domain/credit/controller/CreditController.java
+++ b/src/main/java/com/proovy/domain/credit/controller/CreditController.java
@@ -1,9 +1,13 @@
 package com.proovy.domain.credit.controller;
 
+import com.proovy.domain.credit.dto.request.CreditUseRequest;
+import com.proovy.domain.credit.dto.response.CreditBalanceResponse;
 import com.proovy.domain.credit.dto.response.CreditCostResponse;
 import com.proovy.domain.credit.dto.response.CreditHistoryResponse;
+import com.proovy.domain.credit.dto.response.CreditUseResponse;
 import com.proovy.domain.credit.service.CreditCostService;
 import com.proovy.domain.credit.service.CreditHistoryService;
+import com.proovy.domain.credit.service.CreditUseService;
 import com.proovy.global.response.ApiResponse;
 import com.proovy.global.security.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,14 +16,12 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -30,6 +32,7 @@ public class CreditController {
 
     private final CreditHistoryService creditHistoryService;
     private final CreditCostService creditCostService;
+    private final CreditUseService creditUseService;
 
     @GetMapping("/history")
     @Operation(
@@ -110,5 +113,94 @@ public class CreditController {
     public ResponseEntity<ApiResponse<CreditCostResponse>> getCreditCosts() {
         CreditCostResponse response = creditCostService.getCreditCosts();
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/balance")
+    @Operation(
+            operationId = "03_getCreditBalance",
+            summary = "크레딧 잔액 조회",
+            description = "현재 사용자의 크레딧 잔액을 조회합니다. checkCost 파라미터를 통해 특정 비용 사용 가능 여부도 확인할 수 있습니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = CreditBalanceResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(schema = @Schema(example = "{\"isSuccess\":false,\"code\":\"AUTH4013\",\"message\":\"유효하지 않은 토큰입니다.\"}"))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자 없음",
+                    content = @Content(schema = @Schema(example = "{\"isSuccess\":false,\"code\":\"USER4041\",\"message\":\"사용자를 찾을 수 없습니다.\"}"))
+            )
+    })
+    public ResponseEntity<ApiResponse<CreditBalanceResponse>> getCreditBalance(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+
+            @Parameter(description = "사용 가능 여부를 확인할 비용 (선택)", example = "10")
+            @RequestParam(required = false) Integer checkCost
+    ) {
+        Long userId = userPrincipal.getUserId();
+        CreditBalanceResponse response = creditUseService.getBalance(userId, checkCost);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/use")
+    @Operation(
+            operationId = "04_useCredit",
+            summary = "크레딧 사용 (차감)",
+            description = "AI 기능 사용 시 크레딧을 차감합니다. 난이도에 따라 비용이 조정됩니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "처리 완료 (성공/실패 여부는 응답의 success 필드로 확인)",
+                    content = @Content(schema = @Schema(implementation = CreditUseResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(schema = @Schema(example = "{\"isSuccess\":false,\"code\":\"AUTH4013\",\"message\":\"유효하지 않은 토큰입니다.\"}"))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자 없음",
+                    content = @Content(schema = @Schema(example = "{\"isSuccess\":false,\"code\":\"USER4041\",\"message\":\"사용자를 찾을 수 없습니다.\"}"))
+            )
+    })
+    public ResponseEntity<ApiResponse<CreditUseResponse>> useCredit(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody CreditUseRequest request
+    ) {
+        Long userId = userPrincipal.getUserId();
+        CreditUseResponse response = creditUseService.useCredit(userId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/estimate")
+    @Operation(
+            operationId = "05_estimateCost",
+            summary = "예상 크레딧 비용 조회",
+            description = "특정 기능 실행 시 소모될 예상 크레딧을 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공"
+            )
+    })
+    public ResponseEntity<ApiResponse<Integer>> estimateCost(
+            @Parameter(description = "기능 이름 (Solve, Explain, CreateGraph, Variant, Solution, Check)", example = "Solve")
+            @RequestParam String featureName,
+
+            @Parameter(description = "문제 난이도 (easy, medium, hard)", example = "medium")
+            @RequestParam(required = false, defaultValue = "easy") String difficulty
+    ) {
+        int cost = creditUseService.getEstimatedCost(featureName, difficulty);
+        return ResponseEntity.ok(ApiResponse.success(cost));
     }
 }

--- a/src/main/java/com/proovy/domain/credit/dto/request/CreditUseRequest.java
+++ b/src/main/java/com/proovy/domain/credit/dto/request/CreditUseRequest.java
@@ -1,0 +1,33 @@
+package com.proovy.domain.credit.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "크레딧 사용 요청")
+public class CreditUseRequest {
+
+    @NotBlank
+    @Schema(description = "이벤트 타입", example = "LLM_QUERY")
+    private String eventType;
+
+    @Schema(description = "문제 난이도 (easy, medium, hard)", example = "medium")
+    private String difficulty;
+
+    @Schema(description = "기능 이름", example = "Solve")
+    private String featureName;
+
+    @Schema(description = "설명", example = "이차방정식 문제 풀이")
+    private String description;
+
+    @Schema(description = "직접 지정할 크레딧 양 (null이면 자동 계산)", example = "10")
+    private Integer amount;
+}

--- a/src/main/java/com/proovy/domain/credit/dto/response/CreditBalanceResponse.java
+++ b/src/main/java/com/proovy/domain/credit/dto/response/CreditBalanceResponse.java
@@ -1,0 +1,42 @@
+package com.proovy.domain.credit.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "크레딧 잔액 조회 응답")
+public class CreditBalanceResponse {
+
+    @Schema(description = "일일 무료 크레딧 잔액")
+    private Integer dailyFreeCredit;
+
+    @Schema(description = "일일 무료 크레딧 한도")
+    private Integer dailyFreeLimit;
+
+    @Schema(description = "일일 크레딧 만료 시간")
+    private LocalDateTime dailyExpiresAt;
+
+    @Schema(description = "무료 크레딧 잔액")
+    private Integer freeCredit;
+
+    @Schema(description = "유료 크레딧 잔액")
+    private Integer paidCredit;
+
+    @Schema(description = "유료 크레딧 만료 시간")
+    private LocalDateTime paidExpiresAt;
+
+    @Schema(description = "총 사용 가능 크레딧")
+    private Integer totalAvailable;
+
+    @Schema(description = "지정된 비용을 사용할 수 있는지 여부")
+    private Boolean canUse;
+
+    @Schema(description = "확인한 비용 (canUse 확인용)")
+    private Integer checkedCost;
+}

--- a/src/main/java/com/proovy/domain/credit/dto/response/CreditCostResponse.java
+++ b/src/main/java/com/proovy/domain/credit/dto/response/CreditCostResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @Builder
@@ -15,6 +16,12 @@ public class CreditCostResponse {
 
     @Schema(description = "비용 정책 목록")
     private List<CreditCostItemDto> costs;
+
+    @Schema(description = "기능별 비용 목록")
+    private List<FeatureCostDto> featureCosts;
+
+    @Schema(description = "난이도별 배율")
+    private Map<String, Double> difficultyMultipliers;
 
     @Getter
     @Builder
@@ -33,5 +40,27 @@ public class CreditCostResponse {
 
         @Schema(description = "고정 비용 여부", example = "true")
         private Boolean isFixed;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "기능별 크레딧 비용")
+    public static class FeatureCostDto {
+
+        @Schema(description = "기능 이름", example = "Solve")
+        private String featureName;
+
+        @Schema(description = "기본 비용", example = "10")
+        private Integer baseCost;
+
+        @Schema(description = "쉬운 난이도 비용", example = "10")
+        private Integer easyCost;
+
+        @Schema(description = "중간 난이도 비용", example = "15")
+        private Integer mediumCost;
+
+        @Schema(description = "어려운 난이도 비용", example = "20")
+        private Integer hardCost;
     }
 }

--- a/src/main/java/com/proovy/domain/credit/dto/response/CreditUseResponse.java
+++ b/src/main/java/com/proovy/domain/credit/dto/response/CreditUseResponse.java
@@ -1,0 +1,47 @@
+package com.proovy.domain.credit.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "크레딧 사용 응답")
+public class CreditUseResponse {
+
+    @Schema(description = "차감 성공 여부")
+    private Boolean success;
+
+    @Schema(description = "실제 차감된 크레딧 양")
+    private Integer usedAmount;
+
+    @Schema(description = "크레딧 잔액 정보")
+    private BalanceDto balance;
+
+    @Schema(description = "크레딧 부족 여부 (true면 잔액 부족)")
+    private Boolean insufficientCredit;
+
+    @Schema(description = "메시지")
+    private String message;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "잔액 정보")
+    public static class BalanceDto {
+
+        @Schema(description = "일일 무료 크레딧 잔액")
+        private Integer dailyFreeCredit;
+
+        @Schema(description = "무료 크레딧 잔액")
+        private Integer freeCredit;
+
+        @Schema(description = "유료 크레딧 잔액")
+        private Integer paidCredit;
+
+        @Schema(description = "총 사용 가능 크레딧")
+        private Integer totalAvailable;
+    }
+}

--- a/src/main/java/com/proovy/domain/credit/repository/CreditBalanceRepository.java
+++ b/src/main/java/com/proovy/domain/credit/repository/CreditBalanceRepository.java
@@ -1,7 +1,9 @@
 package com.proovy.domain.credit.repository;
 
 import com.proovy.domain.credit.entity.CreditBalance;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -11,4 +13,8 @@ public interface CreditBalanceRepository extends JpaRepository<CreditBalance, Lo
 
     @Query("SELECT cb FROM CreditBalance cb WHERE cb.user.id = :userId")
     Optional<CreditBalance> findByUserId(@Param("userId") Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT cb FROM CreditBalance cb WHERE cb.user.id = :userId")
+    Optional<CreditBalance> findByUserIdForUpdate(@Param("userId") Long userId);
 }

--- a/src/main/java/com/proovy/domain/credit/service/CreditCostService.java
+++ b/src/main/java/com/proovy/domain/credit/service/CreditCostService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -17,6 +18,23 @@ public class CreditCostService {
     // TODO: DB에서 관리하도록 변경
     private static final int OCR_COST = 10;
     private static final int CODE_EXECUTION_COST = 5;
+
+    // 기능별 기본 비용
+    private static final Map<String, Integer> FEATURE_BASE_COST = Map.of(
+            "Solve", 10,
+            "Explain", 5,
+            "CreateGraph", 5,
+            "Variant", 5,
+            "Solution", 20,
+            "Check", 3
+    );
+
+    // 난이도별 배율
+    private static final Map<String, Double> DIFFICULTY_MULTIPLIER = Map.of(
+            "easy", 1.0,
+            "medium", 1.5,
+            "hard", 2.0
+    );
 
     /**
      * 크레딧 비용 정책 조회
@@ -52,6 +70,24 @@ public class CreditCostService {
         log.info("크레딧 비용 정책 조회 완료, 총 {}개 항목", costs.size());
         return CreditCostResponse.builder()
                 .costs(costs)
+                .featureCosts(buildFeatureCosts())
+                .difficultyMultipliers(DIFFICULTY_MULTIPLIER)
                 .build();
+    }
+
+    private List<CreditCostResponse.FeatureCostDto> buildFeatureCosts() {
+        List<CreditCostResponse.FeatureCostDto> featureCosts = new ArrayList<>();
+
+        for (Map.Entry<String, Integer> entry : FEATURE_BASE_COST.entrySet()) {
+            featureCosts.add(CreditCostResponse.FeatureCostDto.builder()
+                    .featureName(entry.getKey())
+                    .baseCost(entry.getValue())
+                    .easyCost(entry.getValue())
+                    .mediumCost((int) Math.ceil(entry.getValue() * 1.5))
+                    .hardCost(entry.getValue() * 2)
+                    .build());
+        }
+
+        return featureCosts;
     }
 }

--- a/src/main/java/com/proovy/domain/credit/service/CreditUseService.java
+++ b/src/main/java/com/proovy/domain/credit/service/CreditUseService.java
@@ -79,7 +79,7 @@ public class CreditUseService {
      */
     @Transactional
     public CreditUseResponse useCredit(Long userId, CreditUseRequest request) {
-        CreditBalance balance = creditBalanceRepository.findByUserId(userId)
+        CreditBalance balance = creditBalanceRepository.findByUserIdForUpdate(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER4041));
 
         // 비용 계산
@@ -131,13 +131,16 @@ public class CreditUseService {
         }
 
         // 이벤트 타입 기반 고정 비용
-        try {
-            CreditEventType eventType = CreditEventType.valueOf(request.getEventType());
-            if (EVENT_TYPE_COST.containsKey(eventType)) {
-                return EVENT_TYPE_COST.get(eventType);
+        String requestEventType = request.getEventType();
+        if (requestEventType != null) {
+            try {
+                CreditEventType eventType = CreditEventType.valueOf(requestEventType);
+                if (EVENT_TYPE_COST.containsKey(eventType)) {
+                    return EVENT_TYPE_COST.get(eventType);
+                }
+            } catch (IllegalArgumentException ignored) {
+                // 알 수 없는 이벤트 타입은 기능별 비용으로 계산
             }
-        } catch (IllegalArgumentException ignored) {
-            // 알 수 없는 이벤트 타입은 기능별 비용으로 계산
         }
 
         // 기능 이름 기반 비용 계산 (난이도 적용)
@@ -184,11 +187,14 @@ public class CreditUseService {
         int freeUsed = freeBefore - balance.getFreeCredit();
         int paidUsed = paidBefore - balance.getPaidCredit();
 
-        CreditEventType eventType;
-        try {
-            eventType = CreditEventType.valueOf(request.getEventType());
-        } catch (IllegalArgumentException e) {
-            eventType = CreditEventType.LLM_QUERY; // 기본값
+        CreditEventType eventType = CreditEventType.LLM_QUERY;
+        String requestEventType = request.getEventType();
+        if (requestEventType != null) {
+            try {
+                eventType = CreditEventType.valueOf(requestEventType);
+            } catch (IllegalArgumentException ignored) {
+                // 기본값 유지
+            }
         }
 
         String eventName = request.getFeatureName() != null

--- a/src/main/java/com/proovy/domain/credit/service/CreditUseService.java
+++ b/src/main/java/com/proovy/domain/credit/service/CreditUseService.java
@@ -1,0 +1,222 @@
+package com.proovy.domain.credit.service;
+
+import com.proovy.domain.credit.dto.request.CreditUseRequest;
+import com.proovy.domain.credit.dto.response.CreditBalanceResponse;
+import com.proovy.domain.credit.dto.response.CreditUseResponse;
+import com.proovy.domain.credit.entity.CreditBalance;
+import com.proovy.domain.credit.entity.CreditChangeType;
+import com.proovy.domain.credit.entity.CreditEventType;
+import com.proovy.domain.credit.entity.CreditHistory;
+import com.proovy.domain.credit.entity.CreditType;
+import com.proovy.domain.credit.repository.CreditBalanceRepository;
+import com.proovy.domain.credit.repository.CreditHistoryRepository;
+import com.proovy.global.exception.BusinessException;
+import com.proovy.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CreditUseService {
+
+    private final CreditBalanceRepository creditBalanceRepository;
+    private final CreditHistoryRepository creditHistoryRepository;
+
+    // 기능별 기본 비용
+    private static final Map<String, Integer> FEATURE_BASE_COST = Map.of(
+            "Solve", 10,
+            "Explain", 5,
+            "CreateGraph", 5,
+            "Variant", 5,
+            "Solution", 20,
+            "Check", 3
+    );
+
+    // 난이도별 배율
+    private static final Map<String, Double> DIFFICULTY_MULTIPLIER = Map.of(
+            "easy", 1.0,
+            "medium", 1.5,
+            "hard", 2.0
+    );
+
+    // 이벤트 타입별 고정 비용
+    private static final Map<CreditEventType, Integer> EVENT_TYPE_COST = Map.of(
+            CreditEventType.OCR, 10,
+            CreditEventType.CODE_EXECUTION, 5
+    );
+
+    /**
+     * 크레딧 잔액 조회
+     */
+    @Transactional(readOnly = true)
+    public CreditBalanceResponse getBalance(Long userId, Integer checkCost) {
+        CreditBalance balance = creditBalanceRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER4041));
+
+        Integer totalAvailable = balance.getTotalAvailable();
+        Boolean canUse = checkCost == null || totalAvailable >= checkCost;
+
+        return CreditBalanceResponse.builder()
+                .dailyFreeCredit(balance.getDailyFreeCredit())
+                .dailyFreeLimit(balance.getDailyFreeLimit())
+                .dailyExpiresAt(balance.getDailyExpiresAt())
+                .freeCredit(balance.getFreeCredit())
+                .paidCredit(balance.getPaidCredit())
+                .paidExpiresAt(balance.getPaidExpiresAt())
+                .totalAvailable(totalAvailable)
+                .canUse(canUse)
+                .checkedCost(checkCost)
+                .build();
+    }
+
+    /**
+     * 크레딧 사용 (차감)
+     */
+    @Transactional
+    public CreditUseResponse useCredit(Long userId, CreditUseRequest request) {
+        CreditBalance balance = creditBalanceRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER4041));
+
+        // 비용 계산
+        int cost = calculateCost(request);
+        int totalBefore = balance.getTotalAvailable();
+
+        // 잔액 부족 체크
+        if (totalBefore < cost) {
+            log.warn("크레딧 부족: userId={}, 필요={}, 잔액={}", userId, cost, totalBefore);
+            return CreditUseResponse.builder()
+                    .success(false)
+                    .usedAmount(0)
+                    .balance(buildBalanceDto(balance))
+                    .insufficientCredit(true)
+                    .message("크레딧이 부족합니다. 필요: " + cost + ", 잔액: " + totalBefore)
+                    .build();
+        }
+
+        // 차감 전 잔액 기록 (히스토리용)
+        int dailyBefore = balance.getDailyFreeCredit();
+        int freeBefore = balance.getFreeCredit();
+        int paidBefore = balance.getPaidCredit();
+
+        // 크레딧 차감
+        balance.deductCredit(cost);
+
+        // 히스토리 기록
+        saveCreditHistory(balance, request, cost, dailyBefore, freeBefore, paidBefore);
+
+        log.info("크레딧 사용 완료: userId={}, 사용={}, 잔액={}",
+                userId, cost, balance.getTotalAvailable());
+
+        return CreditUseResponse.builder()
+                .success(true)
+                .usedAmount(cost)
+                .balance(buildBalanceDto(balance))
+                .insufficientCredit(false)
+                .message("크레딧이 차감되었습니다.")
+                .build();
+    }
+
+    /**
+     * 비용 계산
+     */
+    public int calculateCost(CreditUseRequest request) {
+        // 직접 지정된 금액이 있으면 사용
+        if (request.getAmount() != null && request.getAmount() > 0) {
+            return request.getAmount();
+        }
+
+        // 이벤트 타입 기반 고정 비용
+        try {
+            CreditEventType eventType = CreditEventType.valueOf(request.getEventType());
+            if (EVENT_TYPE_COST.containsKey(eventType)) {
+                return EVENT_TYPE_COST.get(eventType);
+            }
+        } catch (IllegalArgumentException ignored) {
+            // 알 수 없는 이벤트 타입은 기능별 비용으로 계산
+        }
+
+        // 기능 이름 기반 비용 계산 (난이도 적용)
+        String featureName = request.getFeatureName();
+        if (featureName != null && FEATURE_BASE_COST.containsKey(featureName)) {
+            int baseCost = FEATURE_BASE_COST.get(featureName);
+            String difficulty = request.getDifficulty();
+            double multiplier = DIFFICULTY_MULTIPLIER.getOrDefault(
+                    difficulty != null ? difficulty.toLowerCase() : "easy",
+                    1.0
+            );
+            return (int) Math.ceil(baseCost * multiplier);
+        }
+
+        // 기본 비용 (LLM_QUERY 등)
+        return 5;
+    }
+
+    /**
+     * 특정 기능의 예상 비용 조회
+     */
+    public int getEstimatedCost(String featureName, String difficulty) {
+        int baseCost = FEATURE_BASE_COST.getOrDefault(featureName, 5);
+        double multiplier = DIFFICULTY_MULTIPLIER.getOrDefault(
+                difficulty != null ? difficulty.toLowerCase() : "easy",
+                1.0
+        );
+        return (int) Math.ceil(baseCost * multiplier);
+    }
+
+    private CreditUseResponse.BalanceDto buildBalanceDto(CreditBalance balance) {
+        return CreditUseResponse.BalanceDto.builder()
+                .dailyFreeCredit(balance.getDailyFreeCredit())
+                .freeCredit(balance.getFreeCredit())
+                .paidCredit(balance.getPaidCredit())
+                .totalAvailable(balance.getTotalAvailable())
+                .build();
+    }
+
+    private void saveCreditHistory(CreditBalance balance, CreditUseRequest request,
+                                   int cost, int dailyBefore, int freeBefore, int paidBefore) {
+        // 어떤 크레딧에서 차감되었는지 판단
+        int dailyUsed = dailyBefore - balance.getDailyFreeCredit();
+        int freeUsed = freeBefore - balance.getFreeCredit();
+        int paidUsed = paidBefore - balance.getPaidCredit();
+
+        CreditType creditType;
+        if (dailyUsed > 0) {
+            creditType = CreditType.DAILY;
+        } else if (freeUsed > 0) {
+            creditType = CreditType.FREE;
+        } else {
+            creditType = CreditType.PAID;
+        }
+
+        CreditEventType eventType;
+        try {
+            eventType = CreditEventType.valueOf(request.getEventType());
+        } catch (IllegalArgumentException e) {
+            eventType = CreditEventType.LLM_QUERY; // 기본값
+        }
+
+        String eventName = request.getFeatureName() != null
+                ? request.getFeatureName() + " 실행"
+                : eventType.getDescription();
+
+        CreditHistory history = CreditHistory.builder()
+                .user(balance.getUser())
+                .eventType(eventType)
+                .eventName(eventName)
+                .description(request.getDescription())
+                .amount(cost)
+                .changeType(CreditChangeType.SPEND)
+                .creditType(creditType)
+                .balanceAfterDaily(balance.getDailyFreeCredit())
+                .balanceAfterFree(balance.getFreeCredit())
+                .balanceAfterPaid(balance.getPaidCredit())
+                .build();
+
+        creditHistoryRepository.save(history);
+    }
+}

--- a/src/main/java/com/proovy/domain/credit/service/CreditUseService.java
+++ b/src/main/java/com/proovy/domain/credit/service/CreditUseService.java
@@ -107,7 +107,7 @@ public class CreditUseService {
         balance.deductCredit(cost);
 
         // 히스토리 기록
-        saveCreditHistory(balance, request, cost, dailyBefore, freeBefore, paidBefore);
+        saveCreditHistory(balance, request, dailyBefore, freeBefore, paidBefore);
 
         log.info("크레딧 사용 완료: userId={}, 사용={}, 잔액={}",
                 userId, cost, balance.getTotalAvailable());
@@ -178,20 +178,11 @@ public class CreditUseService {
     }
 
     private void saveCreditHistory(CreditBalance balance, CreditUseRequest request,
-                                   int cost, int dailyBefore, int freeBefore, int paidBefore) {
+                                   int dailyBefore, int freeBefore, int paidBefore) {
         // 어떤 크레딧에서 차감되었는지 판단
         int dailyUsed = dailyBefore - balance.getDailyFreeCredit();
         int freeUsed = freeBefore - balance.getFreeCredit();
         int paidUsed = paidBefore - balance.getPaidCredit();
-
-        CreditType creditType;
-        if (dailyUsed > 0) {
-            creditType = CreditType.DAILY;
-        } else if (freeUsed > 0) {
-            creditType = CreditType.FREE;
-        } else {
-            creditType = CreditType.PAID;
-        }
 
         CreditEventType eventType;
         try {
@@ -204,12 +195,24 @@ public class CreditUseService {
                 ? request.getFeatureName() + " 실행"
                 : eventType.getDescription();
 
+        // 유형별로 분리 기록해 필터링 왜곡을 방지합니다.
+        saveHistoryItem(balance, eventType, eventName, request.getDescription(), dailyUsed, CreditType.DAILY);
+        saveHistoryItem(balance, eventType, eventName, request.getDescription(), freeUsed, CreditType.FREE);
+        saveHistoryItem(balance, eventType, eventName, request.getDescription(), paidUsed, CreditType.PAID);
+    }
+
+    private void saveHistoryItem(CreditBalance balance, CreditEventType eventType,
+                                 String eventName, String description, int amount, CreditType creditType) {
+        if (amount <= 0) {
+            return;
+        }
+
         CreditHistory history = CreditHistory.builder()
                 .user(balance.getUser())
                 .eventType(eventType)
                 .eventName(eventName)
-                .description(request.getDescription())
-                .amount(cost)
+                .description(description)
+                .amount(amount)
                 .changeType(CreditChangeType.SPEND)
                 .creditType(creditType)
                 .balanceAfterDaily(balance.getDailyFreeCredit())


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #80 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

1. 난이도별 배수 정책
   - easy: 1.0x, medium: 1.5x, hard: 2.0x

2. 기능별 기본 비용
   - Solve: 10, Explain: 5, CreateGraph: 5
   - Variant: 5, Solution: 20, Check: 3

3. 크레딧 차감 로직
   - 무료 크레딧 우선 사용 → 유료 크레딧 사용
   - 잔액 부족 시 insufficientCredit=true 반환

## 📸 스크린샷

<img width="865" height="338" alt="스크린샷 2026-02-05 235732" src="https://github.com/user-attachments/assets/0e9c180f-3eb7-4a04-b606-6001c05686a1" />

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- AI 서버(`Proovy-ai`)에서 이 API를 호출하여 크레딧을 관리합니다
- AI 서버에서는 워크플로우 실행 완료 후 최종 비용을 `/api/credits/use`로 전송합니다
- 현재는 Feature 단위 고정 비용이지만, 추후 토큰 기반 비용 계산으로 확장해야 합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 크레딧 비용 정책 조회: 이벤트·기능별 비용과 난이도별 배수 확인 가능
  * 크레딧 잔액 조회: 일일 무료·유료 잔액, 만료일, 사용 가능 여부와 체크 비용 확인
  * 크레딧 사용 처리: 요청 기반 차감 및 사용 이력 기록
  * 예상 비용 추정: 기능 및 난이도에 따른 사전 비용 계산
  * 요청 유효성 검사 및 응답에 상세한 비용/잔액 정보 포함
<!-- end of auto-generated comment: release notes by coderabbit.ai -->