### PR TITLE
[Chore] 사용자 인증 허가에에서 conversations api 제거

### DIFF
--- a/src/main/java/com/proovy/global/security/SecurityConfig.java
+++ b/src/main/java/com/proovy/global/security/SecurityConfig.java
@@ -38,7 +38,6 @@ public class SecurityConfig {
                         // 인증 없이 접근 가능
                         .requestMatchers("/api/auth/logout").authenticated()
                         .requestMatchers("/api/auth/**").permitAll()
-                    .requestMatchers("/api/conversations", "/api/conversations/**").permitAll()
                         .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/health", "/actuator/health").permitAll()
                         // 나머지는 인증 필요


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #81 

## 🏷️ PR 타입
- [x] 🐛 버그 수정 (Bug Fix)


## 📝 작업 내용

- swagger에 표시되지 않는 문제는 swagger 자체의 반영이 느리기 때문이었음
- conversations api에서 무조건 401에러가 뜨는 버그 해결



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안**
  * 대화 엔드포인트에 대한 인증 요구사항을 적용했습니다. 이제 대화 관련 API에 접근할 때 사용자 인증이 필수입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->