### PR TITLE
[Fix] 회원 탈퇴 시 FK 제약조건 위반 방지를 위한 삭제 메서드 추가

### DIFF
--- a/src/main/java/com/proovy/domain/conversation/repository/ChatMessageRepository.java
+++ b/src/main/java/com/proovy/domain/conversation/repository/ChatMessageRepository.java
@@ -2,6 +2,9 @@ package com.proovy.domain.conversation.repository;
 
 import com.proovy.domain.conversation.entity.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -16,4 +19,8 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
      * 특정 세션의 메시지 개수 조회
      */
     long countByChatSessionId(Long chatSessionId);
+
+    @Modifying
+    @Query("DELETE FROM ChatMessage cm WHERE cm.chatSession.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/proovy/domain/conversation/repository/ChatSessionRepository.java
+++ b/src/main/java/com/proovy/domain/conversation/repository/ChatSessionRepository.java
@@ -3,6 +3,9 @@ package com.proovy.domain.conversation.repository;
 import com.proovy.domain.conversation.entity.ChatSession;
 import com.proovy.domain.conversation.entity.ChatSessionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -28,4 +31,8 @@ public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> 
      * 특정 사용자의 모든 세션 개수 조회
      */
     long countByUserId(Long userId);
+
+    @Modifying
+    @Query("DELETE FROM ChatSession cs WHERE cs.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/proovy/domain/credit/repository/CreditBalanceRepository.java
+++ b/src/main/java/com/proovy/domain/credit/repository/CreditBalanceRepository.java
@@ -4,6 +4,7 @@ import com.proovy.domain.credit.entity.CreditBalance;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -17,4 +18,8 @@ public interface CreditBalanceRepository extends JpaRepository<CreditBalance, Lo
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT cb FROM CreditBalance cb WHERE cb.user.id = :userId")
     Optional<CreditBalance> findByUserIdForUpdate(@Param("userId") Long userId);
+
+    @Modifying
+    @Query("DELETE FROM CreditBalance cb WHERE cb.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/proovy/domain/credit/repository/CreditHistoryRepository.java
+++ b/src/main/java/com/proovy/domain/credit/repository/CreditHistoryRepository.java
@@ -6,6 +6,7 @@ import com.proovy.domain.credit.entity.CreditType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -47,6 +48,10 @@ public interface CreditHistoryRepository extends JpaRepository<CreditHistory, Lo
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate
     );
+
+    @Modifying
+    @Query("DELETE FROM CreditHistory ch WHERE ch.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 
     interface CreditPeriodSummary {
         Long getTotalEarned();

--- a/src/main/java/com/proovy/domain/user/service/UserService.java
+++ b/src/main/java/com/proovy/domain/user/service/UserService.java
@@ -3,6 +3,10 @@ package com.proovy.domain.user.service;
 import com.proovy.domain.asset.repository.AssetRepository;
 import com.proovy.domain.auth.repository.RefreshTokenRepository;
 import com.proovy.domain.auth.service.AccessTokenBlacklistService;
+import com.proovy.domain.conversation.repository.ChatMessageRepository;
+import com.proovy.domain.conversation.repository.ChatSessionRepository;
+import com.proovy.domain.credit.repository.CreditBalanceRepository;
+import com.proovy.domain.credit.repository.CreditHistoryRepository;
 import com.proovy.domain.note.repository.NoteRepository;
 import com.proovy.domain.user.dto.response.DeleteUserResponse;
 import com.proovy.domain.user.dto.response.MyProfileResponse;
@@ -39,6 +43,10 @@ public class UserService {
     private final UserPlanRepository userPlanRepository;
     private final AssetRepository assetRepository;
     private final NoteRepository noteRepository;
+    private final CreditBalanceRepository creditBalanceRepository;
+    private final CreditHistoryRepository creditHistoryRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatSessionRepository chatSessionRepository;
     private final S3Service s3Service;
     private final RefreshTokenRepository refreshTokenRepository;
     private final AccessTokenBlacklistService accessTokenBlacklistService;
@@ -183,7 +191,11 @@ public class UserService {
             }
         });
 
-        // DB 데이터 삭제
+        // DB 데이터 삭제 (FK 순서: 자식 → 부모)
+        chatMessageRepository.deleteAllByUserId(userId);
+        chatSessionRepository.deleteAllByUserId(userId);
+        creditHistoryRepository.deleteAllByUserId(userId);
+        creditBalanceRepository.deleteAllByUserId(userId);
         assetRepository.deleteAllByUserId(userId);
         noteRepository.deleteAllByUserId(userId);
         userPlanRepository.deleteAllByUserId(userId);


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #93 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

### 회원 탈퇴 시 FK 제약조건 위반으로 발생하던 500 에러 수정

- User 삭제 전 FK로 연결된 모든 하위 데이터 명시적 삭제 로직 추가
- 누락되어 있던 Repository에 `deleteAllByUserId` 메서드 구현
- 외래 키 관계를 고려하여 삭제 순서를 **자식 → 부모**로 보장

#### 추가된 삭제 대상 테이블
- chat_messages (→ chat_sessions FK)
- chat_sessions (→ users FK)
- credit_history (→ users FK)
- credit_balance (→ users FK)

#### 최종 삭제 순서
1. chat_messages  
2. chat_sessions  
3. credit_history  
4. credit_balance  
5. assets  
6. notes  
7. user_plans  
8. users

→ 모든 FK 참조 데이터 삭제 후 User 삭제가 수행되어 500 에러 없이 탈퇴 처리됩니다.

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- DB 설정 문제(On Delete Cascade)가 아닌 애플리케이션 로직 누락이 원인이었습니다.
- 명시적 삭제 방식을 유지하여 도메인 흐름을 코드 레벨에서 제어합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**정크(Chores)**
- 사용자 계정 삭제 시스템을 개선하여 모든 관련 데이터가 데이터 무결성을 준수하는 올바른 순서로 안전하게 처리되도록 하였습니다. 사용자 정보 삭제 프로세스의 안정성과 신뢰성이 전반적으로 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->