### PR TITLE
[Fix] 노트 생성 api에서 conversation 관련 로직 제거

### DIFF
--- a/src/main/java/com/proovy/domain/note/controller/NoteController.java
+++ b/src/main/java/com/proovy/domain/note/controller/NoteController.java
@@ -13,6 +13,9 @@ import com.proovy.global.response.ApiResponse;
 import com.proovy.global.security.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -48,7 +51,30 @@ public class NoteController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "200",
-                    description = "노트 생성 성공"
+                    description = "노트 생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "노트 생성 성공 예시",
+                                    summary = "새 노트 생성 성공 응답",
+                                    value = """
+                                            {
+                                                \"isSuccess\": true,
+                                                \"code\": \"COMMON201\",
+                                                \"message\": \"노트가 생성되었습니다.\",
+                                                \"result\": {
+                                                    \"noteId\": 1,
+                                                    \"title\": \"새 노트 2026-02-09 19:19\",
+                                                    \"titleGeneratedBy\": \"SYSTEM\",
+                                                    \"conversationLimit\": 50,
+                                                    \"firstConversation\": null,
+                                                    \"createdAt\": \"2026-02-09T19:19:20.8583209\"
+                                                }
+                                            }
+                                            """
+                            )
+                    )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",

--- a/src/main/java/com/proovy/domain/note/controller/NoteController.java
+++ b/src/main/java/com/proovy/domain/note/controller/NoteController.java
@@ -34,19 +34,15 @@ public class NoteController {
     @Operation(
             summary = "새 노트 생성",
             description = """
-                    첫 메시지를 전송하면 자동으로 새 노트가 생성됩니다.
-                    
-                    노트 제목은 AI가 대화 내용을 요약하여 자동 생성합니다.
-                    (현재는 임시로 첫 메시지를 제목으로 사용)
-                    
+                    새 노트를 생성합니다.
+
+                    - 이 API는 노트 리소스만 생성하며, 대화/메시지는 생성하지 않습니다.
+                    - 요청 본문에 제목을 전달하지 않으면 서버에서 현재 시각을 포함한 더미 제목을 자동으로 생성합니다.
+
                     **생성 제한 (요금제별)**
                     - Free: 2개
                     - Standard: 10개
                     - Pro: 20개
-                    
-                    **멘션 기능**
-                    - `#` 파일 멘션: mentionedAssetIds
-                    - `@` 도구 멘션: mentionedToolCodes (SOLUTION, GRAPH, VARIATION)
                     """
     )
     @ApiResponses({
@@ -56,15 +52,11 @@ public class NoteController {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",
-                    description = "메시지 내용 없음 (NOTE4002), 메시지 길이 초과 (NOTE4003), 유효하지 않은 도구 코드 (TOOL4001)"
+                    description = "잘못된 요청 (유효성 검사 실패 등)"
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "403",
                     description = "노트 생성 한도 초과 (NOTE4031)"
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404",
-                    description = "존재하지 않는 파일 (ASSET4041)"
             )
     })
     public ApiResponse<CreateNoteResponse> createNote(

--- a/src/main/java/com/proovy/domain/note/dto/request/CreateNoteRequest.java
+++ b/src/main/java/com/proovy/domain/note/dto/request/CreateNoteRequest.java
@@ -1,22 +1,10 @@
 package com.proovy.domain.note.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-import java.util.List;
-
 public record CreateNoteRequest(
-        @NotBlank(message = "메시지 내용을 입력해주세요.")
-        @Size(max = 5000, message = "메시지는 5000자 이내로 입력해주세요.")
-        String firstMessage,
-
-        List<Long> mentionedAssetIds,
-
-        List<String> mentionedToolCodes
+        @Size(max = 200, message = "노트 제목은 200자 이내로 입력해주세요.")
+        String title
 ) {
-    public CreateNoteRequest {
-        mentionedAssetIds = mentionedAssetIds != null ? mentionedAssetIds : List.of();
-        mentionedToolCodes = mentionedToolCodes != null ? mentionedToolCodes : List.of();
-    }
 }
 

--- a/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
+++ b/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
@@ -30,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.proovy.global.infra.s3.S3Service;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -49,13 +50,9 @@ public class NoteServiceImpl implements NoteService {
     private final com.proovy.domain.user.repository.UserPlanRepository userPlanRepository;
     private final S3Service s3Service;
 
-    // 허용된 도구 코드 목록 (실제로는 별도 관리 필요)
-    private static final Set<String> ALLOWED_TOOL_CODES = Set.of("SOLUTION", "GRAPH", "VARIATION");
-
     @Override
     public CreateNoteResponse createNote(Long userId, CreateNoteRequest request) {
-        log.info("노트 생성 요청 - userId: {}, firstMessage length: {}", userId,
-                request.firstMessage() != null ? request.firstMessage().length() : 0);
+                log.info("노트 생성 요청 - userId: {}, title: {}", userId, request.title());
 
         // 1. 사용자 조회
         User user = userRepository.findById(userId)
@@ -73,170 +70,46 @@ public class NoteServiceImpl implements NoteService {
             throw new BusinessException(ErrorCode.NOTE4031);
         }
 
-        // 3. mentionedAssetIds 검증
-        List<Asset> mentionedAssets = new ArrayList<>();
-        if (request.mentionedAssetIds() != null && !request.mentionedAssetIds().isEmpty()) {
-            List<Long> uniqueAssetIds = request.mentionedAssetIds().stream()
-                    .distinct()
-                    .toList();
-            mentionedAssets = assetRepository.findAllByIdInAndUserId(uniqueAssetIds, userId);
-            if (mentionedAssets.size() != uniqueAssetIds.size()) {
-                throw new BusinessException(ErrorCode.ASSET4041);
-            }
-        }
-
-        // 4. mentionedToolCodes 검증
-        if (request.mentionedToolCodes() != null) {
-            for (String toolCode : request.mentionedToolCodes()) {
-                if (!ALLOWED_TOOL_CODES.contains(toolCode)) {
-                    throw new BusinessException(ErrorCode.TOOL4001);
-                }
-            }
-        }
-
-        // 5. 노트 생성 (제목은 우선 간단하게 생성)
-        String simpleTitle = generateSimpleTitle(request.firstMessage());
+        // 3. 노트 제목 결정 (요청에 제목이 없으면 더미 제목 생성)
+        String resolvedTitle = generateNoteTitle(request.title());
         Note note = Note.builder()
                 .user(user)
-                .title(simpleTitle)
+                .title(resolvedTitle)
                 .contentMd("")
                 .build();
         note = noteRepository.save(note);
-
-        // 6. Conversation 생성
-        Conversation conversation = Conversation.builder()
-                .note(note)
-                .build();
-        conversation = conversationRepository.save(conversation);
-
-        // 7. User Message 생성
-        final Message userMessage = messageRepository.save(Message.builder()
-                .conversation(conversation)
-                .role(MessageRole.USER)
-                .content(request.firstMessage())
-                .status(MessageStatus.COMPLETED)
-                .build());
-
-        // 8. User Message의 Asset 연결
-        if (!mentionedAssets.isEmpty()) {
-            List<MessageAsset> messageAssets = mentionedAssets.stream()
-                    .map(asset -> MessageAsset.builder()
-                            .message(userMessage)
-                            .asset(asset)
-                            .build())
-                    .toList();
-            messageAssetRepository.saveAll(messageAssets);
-        }
-
-        // 9. User Message의 Tool 연결
-        if (request.mentionedToolCodes() != null && !request.mentionedToolCodes().isEmpty()) {
-            List<MessageTool> messageTools = request.mentionedToolCodes().stream()
-                    .map(toolCode -> MessageTool.builder()
-                            .message(userMessage)
-                            .toolCode(toolCode)
-                            .build())
-                    .toList();
-            messageToolRepository.saveAll(messageTools);
-        }
-
-        // 10. Assistant Message 생성 (임시 응답)
-        String assistantContent = "집합론 문제를 분석하고 해설지를 생성하겠습니다...";
-        final Message assistantMessage = messageRepository.save(Message.builder()
-                .conversation(conversation)
-                .role(MessageRole.ASSISTANT)
-                .content(assistantContent)
-                .status(MessageStatus.STREAMING)
-                .build());
-
-        // 11. Assistant Message의 Tool 연결 (사용된 도구)
-        if (request.mentionedToolCodes() != null && !request.mentionedToolCodes().isEmpty()) {
-            List<MessageTool> assistantMessageTools = request.mentionedToolCodes().stream()
-                    .map(toolCode -> MessageTool.builder()
-                            .message(assistantMessage)
-                            .toolCode(toolCode)
-                            .build())
-                    .toList();
-            messageToolRepository.saveAll(assistantMessageTools);
-        }
-
         log.info("노트 생성 완료 - noteId: {}", note.getId());
 
-        // 12. Response 생성
-        return buildCreateNoteResponse(
-                note,
-                conversation,
-                userMessage,
-                assistantMessage,
-                mentionedAssets,
-                request.mentionedToolCodes()
-        );
-    }
+        // 4. 응답 생성 (대화/메시지는 생성하지 않음)
+        int conversationLimit = 50; // TODO: PlanType에 대화 제한 수가 추가되면 해당 값 사용
+        String titleGeneratedBy = (request.title() == null || request.title().isBlank()) ? "SYSTEM" : "USER";
 
-    /**
-     * 간단한 제목 생성 (AI 사용 전까지 임시)
-     */
-    private String generateSimpleTitle(String firstMessage) {
-        // 첫 메시지에서 최대 50자까지 제목으로 사용
-        String title = firstMessage.replaceAll("\\s+", " ").trim();
-        if (title.length() > 50) {
-            title = title.substring(0, 50);
-        }
-        return title;
-    }
-
-    /**
-     * CreateNoteResponse 빌드
-     */
-    private CreateNoteResponse buildCreateNoteResponse(
-            Note note,
-            Conversation conversation,
-            Message userMessage,
-            Message assistantMessage,
-            List<Asset> mentionedAssets,
-            List<String> mentionedToolCodes
-    ) {
-        // MentionedAssets DTO 변환
-        List<CreateNoteResponse.MentionedAssetDto> mentionedAssetDtos = mentionedAssets.stream()
-                .map(asset -> new CreateNoteResponse.MentionedAssetDto(
-                        asset.getId(),
-                        asset.getFileName()
-                ))
-                .collect(Collectors.toList());
-
-        // UserMessage DTO
-        CreateNoteResponse.UserMessageDto userMessageDto = new CreateNoteResponse.UserMessageDto(
-                userMessage.getId(),
-                userMessage.getContent(),
-                mentionedAssetDtos,
-                mentionedToolCodes != null ? mentionedToolCodes : List.of(),
-                userMessage.getCreatedAt()
-        );
-
-        // AssistantMessage DTO
-        CreateNoteResponse.AssistantMessageDto assistantMessageDto = new CreateNoteResponse.AssistantMessageDto(
-                assistantMessage.getId(),
-                assistantMessage.getContent(),
-                mentionedToolCodes != null ? mentionedToolCodes : List.of(),
-                assistantMessage.getStatus().name(),
-                assistantMessage.getCreatedAt()
-        );
-
-        // FirstConversation DTO
-        CreateNoteResponse.FirstConversationDto firstConversationDto = new CreateNoteResponse.FirstConversationDto(
-                conversation.getId(),
-                userMessageDto,
-                assistantMessageDto
-        );
-
-        // CreateNoteResponse
         return new CreateNoteResponse(
                 note.getId(),
                 note.getTitle(),
-                "USER", // 현재는 AI 사용하지 않으므로 USER로 표시
-                50, // 기본 대화 제한
-                firstConversationDto,
+                titleGeneratedBy,
+                conversationLimit,
+                null,
                 note.getCreatedAt()
         );
+    }
+
+    /**
+     * 노트 제목 생성
+     * - 요청에 제목이 있으면 공백/길이만 정리하여 사용
+     * - 없으면 현재 시각 기반의 더미 제목 생성
+     */
+    private String generateNoteTitle(String rawTitle) {
+        if (rawTitle != null && !rawTitle.isBlank()) {
+            String normalized = rawTitle.replaceAll("\\s+", " ").trim();
+            if (normalized.length() > 200) {
+                normalized = normalized.substring(0, 200);
+            }
+            return normalized;
+        }
+
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+        return "새 노트 " + timestamp;
     }
 
     @Override


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #103 

## 🏷️ PR 타입

- [x] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)

## 📝 작업 내용

- POST /api/notes를 첫 메시지/대화 생성 로직 없이, 제목(없으면 더미 제목)만으로 순수 노트 생성하는 API로 변경했습니다.
- 이에 맞춰 CreateNoteRequest/Response와 NoteServiceImpl, NoteController Swagger 문서를 실제 응답(JSON 예제 포함)과 일치하도록 수정했습니다.

## 📸 스크린샷

- <img width="659" height="682" alt="{3EDA4313-B9DA-4265-A828-33F211B36799}" src="https://github.com/user-attachments/assets/f99e6604-78e4-439c-8e32-7b24709538b1" />

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 노트 제목을 명시하지 않을 경우에도, request body에 빈 json 이 들어가 있어야합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 노트 생성 API가 단순화되었습니다. 이제 제목만 제공하면 노트를 쉽게 생성할 수 있습니다.

* **Documentation**
  * API 문서화가 개선되었습니다. 상세한 응답 예시와 오류 설명이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->