### PR TITLE
[Feat] flyway V0.1~V15 마이그레이션-엔티티 정합성 최종 검증

### DIFF
--- a/src/main/java/com/proovy/global/config/SwaggerConfig.java
+++ b/src/main/java/com/proovy/global/config/SwaggerConfig.java
@@ -5,13 +5,17 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import java.util.List;
 
 import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
+import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.function.RouterFunction;
 import org.springframework.web.servlet.function.RouterFunctions;
 import org.springframework.web.servlet.function.ServerResponse;
@@ -21,12 +25,16 @@ import org.springframework.web.servlet.function.ServerResponse;
 public class SwaggerConfig {
 
     private static final String BEARER_TOKEN_PREFIX = "Bearer";
+    private final String publicBaseUrl;
+
+    public SwaggerConfig(@Value("${proovy.api.public-base-url:}") String publicBaseUrl) {
+        this.publicBaseUrl = publicBaseUrl;
+    }
 
     @Bean
     public OpenAPI openAPI() {
         String securitySchemeName = "bearerAuth";
-
-        return new OpenAPI()
+        OpenAPI openApi = new OpenAPI()
                 .info(new Info()
                         .title("Proovy API")
                         .description("Proovy 백엔드 API 명세서")
@@ -40,6 +48,14 @@ public class SwaggerConfig {
                                         .scheme("bearer")
                                         .bearerFormat("JWT")
                                         .description("JWT 액세스 토큰을 입력하세요 (Bearer 접두사 없이)")));
+
+        if (StringUtils.hasText(publicBaseUrl)) {
+            openApi.setServers(List.of(new Server()
+                    .url(publicBaseUrl)
+                    .description("Public Server")));
+        }
+
+        return openApi;
     }
 
     @Bean

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,6 +32,9 @@ spring:
 springdoc:
   swagger-ui:
     tagsSorter: alpha
+    url: /v3/api-docs
+  api-docs:
+    path: /v3/api-docs
 
 server:
   port: 8080
@@ -103,6 +106,8 @@ jwt:
 proovy:
   ai:
     host: ${PROOVY_AI_HOST:https://api.proovy.ai.kr/ai}
+  api:
+    public-base-url: ${PROOVY_API_BASE_URL:}
 
 ---
 # ===============================
@@ -134,3 +139,7 @@ spring:
     hibernate:
       ddl-auto: validate
     show-sql: false
+
+proovy:
+  api:
+    public-base-url: ${PROOVY_API_BASE_URL:https://api.proovy.ai.kr}

--- a/src/main/resources/db/migration/V10__create_notes.sql
+++ b/src/main/resources/db/migration/V10__create_notes.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS notes (
+    note_id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    title VARCHAR(200) NOT NULL,
+    content_md TEXT,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+    CONSTRAINT fk_notes_user
+        FOREIGN KEY (user_id) REFERENCES users(user_id)
+);

--- a/src/main/resources/db/migration/V11__create_user_plans.sql
+++ b/src/main/resources/db/migration/V11__create_user_plans.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS user_plans (
+    user_plan_id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    plan_type VARCHAR(10) NOT NULL DEFAULT 'FREE',
+    started_at TIMESTAMP,
+    expired_at TIMESTAMP,
+    is_active BOOLEAN DEFAULT true,
+    CONSTRAINT fk_user_plans_user
+        FOREIGN KEY (user_id) REFERENCES users(user_id)
+);

--- a/src/main/resources/db/migration/V12__create_conversations.sql
+++ b/src/main/resources/db/migration/V12__create_conversations.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS conversations (
+    conversation_id BIGSERIAL PRIMARY KEY,
+    note_id BIGINT NOT NULL,
+    created_at TIMESTAMP,
+    CONSTRAINT fk_conversations_note
+        FOREIGN KEY (note_id) REFERENCES notes(note_id)
+);

--- a/src/main/resources/db/migration/V13__create_messages.sql
+++ b/src/main/resources/db/migration/V13__create_messages.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS messages (
+    message_id BIGSERIAL PRIMARY KEY,
+    conversation_id BIGINT NOT NULL,
+    role VARCHAR(20) NOT NULL,
+    content TEXT,
+    status VARCHAR(20),
+    created_at TIMESTAMP,
+    CONSTRAINT fk_messages_conversation
+        FOREIGN KEY (conversation_id) REFERENCES conversations(conversation_id)
+);

--- a/src/main/resources/db/migration/V14__create_message_tools.sql
+++ b/src/main/resources/db/migration/V14__create_message_tools.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS message_tools (
+    id BIGSERIAL PRIMARY KEY,
+    message_id BIGINT NOT NULL,
+    tool_code VARCHAR(50) NOT NULL,
+    CONSTRAINT fk_message_tools_message
+        FOREIGN KEY (message_id) REFERENCES messages(message_id)
+);

--- a/src/main/resources/db/migration/V15__create_message_assets.sql
+++ b/src/main/resources/db/migration/V15__create_message_assets.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS message_assets (
+    id BIGSERIAL PRIMARY KEY,
+    message_id BIGINT NOT NULL,
+    asset_id BIGINT NOT NULL,
+    CONSTRAINT fk_message_assets_message
+        FOREIGN KEY (message_id) REFERENCES messages(message_id),
+    CONSTRAINT fk_message_assets_asset
+        FOREIGN KEY (asset_id) REFERENCES assets(id)
+);


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #107 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- Flyway V0.1~V15 기준으로 전체 13개 JPA 엔티티(User ~ MessageAsset) 컬럼 단위 정합성 최종 검증 완료
- 마이그레이션/테이블/엔티티 매핑 및 FK 의존 순서 검증
  - V0.1 create_users → users (User)
  - V1 create_credit_balance → credit_balance (CreditBalance) [FK: users]
  - V2 backfill_credit_balance (데이터 백필) [FK: users, credit_balance]
  - V3 create_credit_history → credit_history (CreditHistory) [FK: users]
  - V4 create_chat_sessions → chat_sessions (ChatSession) [FK: users]
  - V5 create_chat_messages → chat_messages (ChatMessage) [FK: chat_sessions]
  - V6 create_message_attachments → message_attachments (MessageAttachment) [FK: chat_messages]
  - V7 fix_credit_history_pk (조건부)
  - V8 rename_credit_balance_pk (조건부: balance_id 없으면 스킵)
  - V9 create_assets → assets (Asset) [FK 없음(plain Long)]
  - V10 create_notes → notes (Note) [FK: users]
  - V11 create_user_plans → user_plans (UserPlan) [FK: users]
  - V12 create_conversations → conversations (Conversation) [FK: notes]
  - V13 create_messages → messages (Message) [FK: conversations]
  - V14 create_message_tools → message_tools (MessageTool) [FK: messages]
  - V15 create_message_assets → message_assets (MessageAsset) [FK: messages, assets]
- Redis 엔티티 3개는 SQL 테이블 생성 불필요함을 명시

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트(또는 로컬 검증)를 수행하고 정상 동작을 확인했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * API 문서화 개선 - 공개 서버 URL 설정 기능 추가
  * 노트 관리 기능을 위한 데이터베이스 스키마 확장
  * 사용자 플랜 관리 시스템 추가
  * 대화 및 메시지 저장 기능 구현
  * 메시지 도구 및 자산 연결 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->