### PR TITLE
[Feat] prod ddl-auto=validate 환경에서 tools 테이블 누락으로 인한 부팅 실패 수정

### DIFF
--- a/src/main/resources/db/migration/V16__create_tools.sql
+++ b/src/main/resources/db/migration/V16__create_tools.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS tools (
+    tool_id BIGSERIAL PRIMARY KEY,
+    tool_code VARCHAR(50) NOT NULL UNIQUE,
+    name VARCHAR(100) NOT NULL,
+    description TEXT,
+    icon_type VARCHAR(50),
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    display_order INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP
+);


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #109 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- prod 환경(`ddl-auto: validate`)에서 tools 테이블 누락으로 서버 부팅 실패/무한 재시작 되던 문제 수정
- Flyway 마이그레이션 `V16__create_tools.sql` 추가하여 `tools` 테이블 생성
- 기대 동작:
  - Flyway가 V16 적용 → tools 테이블 생성
  - 이후 ToolDataInitializer가 `toolRepository.count()` 호출 및 초기 데이터 insert 정상 수행

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다 (해당 없음이면 체크 대신 사유 작성)
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- local(`ddl-auto: update`)에서는 Hibernate가 tools 테이블을 자동 생성해 문제가 드러나지 않았음
- prod(`ddl-auto: validate`)에서는 Flyway에 테이블 생성 SQL이 없으면 즉시 부팅 실패하므로,
  앞으로 신규 엔티티 추가 시 Flyway 마이그레이션을 반드시 포함해야 함
