### PR TITLE
[Feat] pgvector 임베딩 저장 + Redis 큐 발행 + 내부 API 연동

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,7 @@ DB_PASSWORD=
 # ===============================
 REDIS_HOST=
 REDIS_PORT=
+INTERNAL_API_TOKEN=
 
 # ===============================
 # KAKAO Login

--- a/src/main/java/com/proovy/domain/embedding/NoteEmbedding.java
+++ b/src/main/java/com/proovy/domain/embedding/NoteEmbedding.java
@@ -42,7 +42,7 @@ public class NoteEmbedding {
 
     @Access(AccessType.FIELD)
     @Column(name = "vector", nullable = false, columnDefinition = "vector(1536)")
-    @ColumnTransformer(write = "?::vector")
+    @ColumnTransformer(read = "vector::text", write = "?::vector")
     private String vector;
 
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/com/proovy/domain/embedding/NoteEmbedding.java
+++ b/src/main/java/com/proovy/domain/embedding/NoteEmbedding.java
@@ -1,0 +1,81 @@
+package com.proovy.domain.embedding;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnTransformer;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "note_embeddings")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoteEmbedding {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "note_id", nullable = false)
+    private Long noteId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "content_hash", nullable = false, length = 64)
+    private String contentHash;
+
+    @Column(name = "embedding_model", nullable = false, length = 50)
+    private String embeddingModel;
+
+    @Access(AccessType.FIELD)
+    @Column(name = "vector", nullable = false, columnDefinition = "vector(1536)")
+    @ColumnTransformer(write = "?::vector")
+    private String vector;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public NoteEmbedding(Long noteId, Long userId, String contentHash, String embeddingModel, String vector) {
+        this.noteId = noteId;
+        this.userId = userId;
+        this.contentHash = contentHash;
+        this.embeddingModel = (embeddingModel == null || embeddingModel.isBlank())
+                ? "text-embedding-3-small" : embeddingModel;
+        this.vector = vector;
+    }
+
+    public void updateVector(String vector, String contentHash) {
+        this.vector = vector;
+        this.contentHash = contentHash;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/proovy/domain/embedding/NoteEmbeddingRepository.java
+++ b/src/main/java/com/proovy/domain/embedding/NoteEmbeddingRepository.java
@@ -1,0 +1,14 @@
+package com.proovy.domain.embedding;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface NoteEmbeddingRepository extends JpaRepository<NoteEmbedding, Long> {
+
+    Optional<NoteEmbedding> findByNoteIdAndEmbeddingModel(Long noteId, String embeddingModel);
+
+    void deleteByNoteId(Long noteId);
+}

--- a/src/main/java/com/proovy/domain/embedding/service/EmbeddingJobPublisher.java
+++ b/src/main/java/com/proovy/domain/embedding/service/EmbeddingJobPublisher.java
@@ -32,6 +32,15 @@ public class EmbeddingJobPublisher {
     private long lockTtl;
 
     public void publishEmbeddingJob(Long noteId, String contentHash, String model) {
+        if (noteId == null) {
+            log.warn("임베딩 작업 발행 생략: noteId가 null입니다.");
+            return;
+        }
+        if (contentHash == null || contentHash.isBlank()) {
+            log.warn("임베딩 작업 발행 생략: contentHash가 비어 있습니다. noteId={}", noteId);
+            return;
+        }
+
         String resolvedModel = (model == null || model.isBlank()) ? DEFAULT_MODEL : model;
         if (TransactionSynchronizationManager.isSynchronizationActive()
                 && TransactionSynchronizationManager.isActualTransactionActive()) {

--- a/src/main/java/com/proovy/domain/embedding/service/EmbeddingJobPublisher.java
+++ b/src/main/java/com/proovy/domain/embedding/service/EmbeddingJobPublisher.java
@@ -7,6 +7,8 @@ import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamRecords;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.Duration;
 import java.util.Map;
@@ -30,12 +32,29 @@ public class EmbeddingJobPublisher {
     private long lockTtl;
 
     public void publishEmbeddingJob(Long noteId, String contentHash, String model) {
-        try {
-            String lockKey = String.format("%s:%d:%s", lockPrefix, noteId, contentHash);
-            Boolean lockAcquired = redisTemplate.opsForValue()
-                    .setIfAbsent(lockKey, "1", Duration.ofSeconds(lockTtl));
+        String resolvedModel = (model == null || model.isBlank()) ? DEFAULT_MODEL : model;
+        if (TransactionSynchronizationManager.isSynchronizationActive()
+                && TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    publishNow(noteId, contentHash, resolvedModel);
+                }
+            });
+            return;
+        }
 
-            if (Boolean.FALSE.equals(lockAcquired)) {
+        publishNow(noteId, contentHash, resolvedModel);
+    }
+
+    private void publishNow(Long noteId, String contentHash, String model) {
+        String lockKey = String.format("%s:%d:%s", lockPrefix, noteId, contentHash);
+        boolean lockAcquired = false;
+        try {
+            lockAcquired = Boolean.TRUE.equals(
+                    redisTemplate.opsForValue().setIfAbsent(lockKey, "1", Duration.ofSeconds(lockTtl))
+            );
+            if (!lockAcquired) {
                 log.info("임베딩 작업 중복 감지. 발행 생략: noteId={}, hash={}", noteId, contentHash);
                 return;
             }
@@ -43,7 +62,7 @@ public class EmbeddingJobPublisher {
             Map<String, String> message = Map.of(
                     "noteId", String.valueOf(noteId),
                     "contentHash", contentHash,
-                    "model", (model == null || model.isBlank()) ? DEFAULT_MODEL : model,
+                    "model", model,
                     "timestamp", String.valueOf(System.currentTimeMillis())
             );
 
@@ -51,9 +70,15 @@ public class EmbeddingJobPublisher {
                     .add(StreamRecords.newRecord()
                             .ofStrings(message)
                             .withStreamKey(streamKey));
+            if (recordId == null) {
+                throw new IllegalStateException("Redis stream recordId is null");
+            }
 
             log.info("임베딩 작업 발행 완료: noteId={}, recordId={}", noteId, recordId);
         } catch (Exception e) {
+            if (lockAcquired) {
+                redisTemplate.delete(lockKey);
+            }
             log.error("임베딩 작업 발행 실패: noteId={}", noteId, e);
         }
     }

--- a/src/main/java/com/proovy/domain/embedding/service/EmbeddingJobPublisher.java
+++ b/src/main/java/com/proovy/domain/embedding/service/EmbeddingJobPublisher.java
@@ -1,0 +1,60 @@
+package com.proovy.domain.embedding.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamRecords;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmbeddingJobPublisher {
+
+    private static final String DEFAULT_MODEL = "text-embedding-3-small";
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${embedding.redis.stream.key}")
+    private String streamKey;
+
+    @Value("${embedding.redis.lock.prefix}")
+    private String lockPrefix;
+
+    @Value("${embedding.redis.lock.ttl}")
+    private long lockTtl;
+
+    public void publishEmbeddingJob(Long noteId, String contentHash, String model) {
+        try {
+            String lockKey = String.format("%s:%d:%s", lockPrefix, noteId, contentHash);
+            Boolean lockAcquired = redisTemplate.opsForValue()
+                    .setIfAbsent(lockKey, "1", Duration.ofSeconds(lockTtl));
+
+            if (Boolean.FALSE.equals(lockAcquired)) {
+                log.info("임베딩 작업 중복 감지. 발행 생략: noteId={}, hash={}", noteId, contentHash);
+                return;
+            }
+
+            Map<String, String> message = Map.of(
+                    "noteId", String.valueOf(noteId),
+                    "contentHash", contentHash,
+                    "model", (model == null || model.isBlank()) ? DEFAULT_MODEL : model,
+                    "timestamp", String.valueOf(System.currentTimeMillis())
+            );
+
+            RecordId recordId = redisTemplate.opsForStream()
+                    .add(StreamRecords.newRecord()
+                            .ofStrings(message)
+                            .withStreamKey(streamKey));
+
+            log.info("임베딩 작업 발행 완료: noteId={}, recordId={}", noteId, recordId);
+        } catch (Exception e) {
+            log.error("임베딩 작업 발행 실패: noteId={}", noteId, e);
+        }
+    }
+}

--- a/src/main/java/com/proovy/domain/embedding/service/NoteEmbeddingService.java
+++ b/src/main/java/com/proovy/domain/embedding/service/NoteEmbeddingService.java
@@ -1,0 +1,54 @@
+package com.proovy.domain.embedding.service;
+
+import com.proovy.domain.embedding.NoteEmbedding;
+import com.proovy.domain.embedding.NoteEmbeddingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class NoteEmbeddingService {
+
+    private static final String DEFAULT_MODEL = "text-embedding-3-small";
+
+    private final NoteEmbeddingRepository embeddingRepository;
+
+    public void upsertEmbedding(Long noteId, Long userId, String contentHash, String model, List<Double> vectorList) {
+        try {
+            String resolvedModel = (model == null || model.isBlank()) ? DEFAULT_MODEL : model;
+            String vectorString = vectorList.stream()
+                    .map(String::valueOf)
+                    .collect(Collectors.joining(",", "[", "]"));
+
+            Optional<NoteEmbedding> existing = embeddingRepository.findByNoteIdAndEmbeddingModel(noteId, resolvedModel);
+
+            if (existing.isPresent()) {
+                NoteEmbedding embedding = existing.get();
+                embedding.updateVector(vectorString, contentHash);
+                log.info("임베딩 업데이트 완료: noteId={}, model={}", noteId, resolvedModel);
+                return;
+            }
+
+            NoteEmbedding embedding = NoteEmbedding.builder()
+                    .noteId(noteId)
+                    .userId(userId)
+                    .contentHash(contentHash)
+                    .embeddingModel(resolvedModel)
+                    .vector(vectorString)
+                    .build();
+            embeddingRepository.save(embedding);
+            log.info("임베딩 신규 저장 완료: noteId={}, model={}", noteId, resolvedModel);
+        } catch (Exception e) {
+            log.error("임베딩 저장 실패: noteId={}", noteId, e);
+            throw new RuntimeException("임베딩 저장 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/proovy/domain/embedding/service/NoteEmbeddingService.java
+++ b/src/main/java/com/proovy/domain/embedding/service/NoteEmbeddingService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -18,11 +19,13 @@ import java.util.stream.Collectors;
 public class NoteEmbeddingService {
 
     private static final String DEFAULT_MODEL = "text-embedding-3-small";
+    private static final int EMBEDDING_DIMENSION = 1536;
 
     private final NoteEmbeddingRepository embeddingRepository;
 
     public void upsertEmbedding(Long noteId, Long userId, String contentHash, String model, List<Double> vectorList) {
         try {
+            validateVector(vectorList);
             String resolvedModel = (model == null || model.isBlank()) ? DEFAULT_MODEL : model;
             String vectorString = vectorList.stream()
                     .map(String::valueOf)
@@ -46,9 +49,23 @@ public class NoteEmbeddingService {
                     .build();
             embeddingRepository.save(embedding);
             log.info("임베딩 신규 저장 완료: noteId={}, model={}", noteId, resolvedModel);
+        } catch (IllegalArgumentException e) {
+            throw e;
         } catch (Exception e) {
             log.error("임베딩 저장 실패: noteId={}", noteId, e);
             throw new RuntimeException("임베딩 저장 실패", e);
+        }
+    }
+
+    private void validateVector(List<Double> vectorList) {
+        if (vectorList == null || vectorList.isEmpty()) {
+            throw new IllegalArgumentException("벡터 데이터가 비어 있습니다.");
+        }
+        if (vectorList.size() != EMBEDDING_DIMENSION) {
+            throw new IllegalArgumentException("벡터 차원은 1536이어야 합니다.");
+        }
+        if (vectorList.stream().anyMatch(Objects::isNull)) {
+            throw new IllegalArgumentException("벡터에 null 값이 포함되어 있습니다.");
         }
     }
 }

--- a/src/main/java/com/proovy/domain/note/controller/InternalNoteController.java
+++ b/src/main/java/com/proovy/domain/note/controller/InternalNoteController.java
@@ -1,7 +1,6 @@
 package com.proovy.domain.note.controller;
 
 import com.proovy.domain.embedding.service.NoteEmbeddingService;
-import com.proovy.domain.note.entity.Note;
 import com.proovy.domain.note.repository.NoteRepository;
 import com.proovy.global.util.HashUtils;
 import jakarta.validation.Valid;
@@ -41,15 +40,15 @@ public class InternalNoteController {
     public ResponseEntity<EmbeddingSourceResponse> getEmbeddingSource(
             @PathVariable Long noteId
     ) {
-        Note note = noteRepository.findById(noteId)
+        NoteRepository.EmbeddingSourceProjection source = noteRepository.findEmbeddingSourceById(noteId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Note not found"));
 
-        String content = note.getContentMd() == null ? "" : note.getContentMd();
+        String content = source.getContentMd() == null ? "" : source.getContentMd();
         String contentHash = HashUtils.sha256(content);
 
         return ResponseEntity.ok(EmbeddingSourceResponse.builder()
-                .noteId(note.getId())
-                .userId(note.getUser().getId())
+                .noteId(source.getNoteId())
+                .userId(source.getUserId())
                 .content(content)
                 .contentHash(contentHash)
                 .model(DEFAULT_MODEL)
@@ -61,10 +60,10 @@ public class InternalNoteController {
             @PathVariable Long noteId,
             @RequestBody @Valid UpsertEmbeddingRequest request
     ) {
-        Note note = noteRepository.findById(noteId)
+        NoteRepository.EmbeddingSourceProjection source = noteRepository.findEmbeddingSourceById(noteId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Note not found"));
 
-        String currentContent = note.getContentMd() == null ? "" : note.getContentMd();
+        String currentContent = source.getContentMd() == null ? "" : source.getContentMd();
         String currentHash = HashUtils.sha256(currentContent);
         if (!currentHash.equals(request.getContentHash())) {
             log.warn("노트 내용 변경 감지. 임베딩 저장 취소: noteId={}", noteId);
@@ -73,7 +72,7 @@ public class InternalNoteController {
 
         embeddingService.upsertEmbedding(
                 noteId,
-                note.getUser().getId(),
+                source.getUserId(),
                 request.getContentHash(),
                 request.getModel(),
                 request.getVector()

--- a/src/main/java/com/proovy/domain/note/controller/InternalNoteController.java
+++ b/src/main/java/com/proovy/domain/note/controller/InternalNoteController.java
@@ -7,18 +7,18 @@ import com.proovy.global.util.HashUtils;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
@@ -32,26 +32,15 @@ import java.util.List;
 public class InternalNoteController {
 
     private static final String DEFAULT_MODEL = "text-embedding-3-small";
+    private static final int EMBEDDING_DIMENSION = 1536;
 
     private final NoteRepository noteRepository;
     private final NoteEmbeddingService embeddingService;
 
-    @Value("${internal.api.token}")
-    private String internalToken;
-
-    private void validateInternalToken(String token) {
-        if (!internalToken.equals(token)) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid internal token");
-        }
-    }
-
     @GetMapping("/{noteId}/embedding-source")
     public ResponseEntity<EmbeddingSourceResponse> getEmbeddingSource(
-            @PathVariable Long noteId,
-            @RequestHeader("X-Internal-Token") String token
+            @PathVariable Long noteId
     ) {
-        validateInternalToken(token);
-
         Note note = noteRepository.findById(noteId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Note not found"));
 
@@ -70,11 +59,8 @@ public class InternalNoteController {
     @PostMapping("/{noteId}/embedding")
     public ResponseEntity<Void> upsertEmbedding(
             @PathVariable Long noteId,
-            @RequestHeader("X-Internal-Token") String token,
             @RequestBody @Valid UpsertEmbeddingRequest request
     ) {
-        validateInternalToken(token);
-
         Note note = noteRepository.findById(noteId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Note not found"));
 
@@ -115,6 +101,7 @@ public class InternalNoteController {
         private String contentHash;
 
         @NotEmpty
-        private List<Double> vector;
+        @Size(min = EMBEDDING_DIMENSION, max = EMBEDDING_DIMENSION, message = "vector must have 1536 dimensions")
+        private List<@NotNull Double> vector;
     }
 }

--- a/src/main/java/com/proovy/domain/note/controller/InternalNoteController.java
+++ b/src/main/java/com/proovy/domain/note/controller/InternalNoteController.java
@@ -1,0 +1,120 @@
+package com.proovy.domain.note.controller;
+
+import com.proovy.domain.embedding.service.NoteEmbeddingService;
+import com.proovy.domain.note.entity.Note;
+import com.proovy.domain.note.repository.NoteRepository;
+import com.proovy.global.util.HashUtils;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/internal/notes")
+@RequiredArgsConstructor
+@Slf4j
+public class InternalNoteController {
+
+    private static final String DEFAULT_MODEL = "text-embedding-3-small";
+
+    private final NoteRepository noteRepository;
+    private final NoteEmbeddingService embeddingService;
+
+    @Value("${internal.api.token}")
+    private String internalToken;
+
+    private void validateInternalToken(String token) {
+        if (!internalToken.equals(token)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid internal token");
+        }
+    }
+
+    @GetMapping("/{noteId}/embedding-source")
+    public ResponseEntity<EmbeddingSourceResponse> getEmbeddingSource(
+            @PathVariable Long noteId,
+            @RequestHeader("X-Internal-Token") String token
+    ) {
+        validateInternalToken(token);
+
+        Note note = noteRepository.findById(noteId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Note not found"));
+
+        String content = note.getContentMd() == null ? "" : note.getContentMd();
+        String contentHash = HashUtils.sha256(content);
+
+        return ResponseEntity.ok(EmbeddingSourceResponse.builder()
+                .noteId(note.getId())
+                .userId(note.getUser().getId())
+                .content(content)
+                .contentHash(contentHash)
+                .model(DEFAULT_MODEL)
+                .build());
+    }
+
+    @PostMapping("/{noteId}/embedding")
+    public ResponseEntity<Void> upsertEmbedding(
+            @PathVariable Long noteId,
+            @RequestHeader("X-Internal-Token") String token,
+            @RequestBody @Valid UpsertEmbeddingRequest request
+    ) {
+        validateInternalToken(token);
+
+        Note note = noteRepository.findById(noteId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Note not found"));
+
+        String currentContent = note.getContentMd() == null ? "" : note.getContentMd();
+        String currentHash = HashUtils.sha256(currentContent);
+        if (!currentHash.equals(request.getContentHash())) {
+            log.warn("노트 내용 변경 감지. 임베딩 저장 취소: noteId={}", noteId);
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        }
+
+        embeddingService.upsertEmbedding(
+                noteId,
+                note.getUser().getId(),
+                request.getContentHash(),
+                request.getModel(),
+                request.getVector()
+        );
+
+        return ResponseEntity.ok().build();
+    }
+
+    @Data
+    @Builder
+    public static class EmbeddingSourceResponse {
+        private Long noteId;
+        private Long userId;
+        private String content;
+        private String contentHash;
+        private String model;
+    }
+
+    @Data
+    public static class UpsertEmbeddingRequest {
+        @NotBlank
+        private String model;
+
+        @NotBlank
+        private String contentHash;
+
+        @NotEmpty
+        private List<Double> vector;
+    }
+}

--- a/src/main/java/com/proovy/domain/note/repository/NoteRepository.java
+++ b/src/main/java/com/proovy/domain/note/repository/NoteRepository.java
@@ -12,6 +12,12 @@ import java.util.List;
 
 public interface NoteRepository extends JpaRepository<Note, Long> {
 
+    interface EmbeddingSourceProjection {
+        Long getNoteId();
+        Long getUserId();
+        String getContentMd();
+    }
+
     List<Note> findByUserIdOrderByCreatedAtDesc(Long userId);
 
     long countByUserId(Long userId);
@@ -25,6 +31,13 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
      * 사용자의 노트 목록 페이지네이션 조회
      */
     Page<Note> findByUserId(Long userId, Pageable pageable);
+
+    @Query("""
+           SELECT n.id AS noteId, n.user.id AS userId, n.contentMd AS contentMd
+           FROM Note n
+           WHERE n.id = :noteId
+           """)
+    java.util.Optional<EmbeddingSourceProjection> findEmbeddingSourceById(@Param("noteId") Long noteId);
 
     /**
      * 특정 사용자의 모든 노트 삭제 (회원 탈퇴용)

--- a/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
+++ b/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
@@ -16,10 +16,12 @@ import com.proovy.domain.note.dto.response.UpdateNoteTitleResponse;
 import com.proovy.domain.note.dto.response.AssetListResponse;
 import com.proovy.domain.note.entity.Note;
 import com.proovy.domain.note.repository.NoteRepository;
+import com.proovy.domain.embedding.service.EmbeddingJobPublisher;
 import com.proovy.domain.user.entity.User;
 import com.proovy.domain.user.repository.UserRepository;
 import com.proovy.global.exception.BusinessException;
 import com.proovy.global.response.ErrorCode;
+import com.proovy.global.util.HashUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -50,6 +52,7 @@ public class NoteServiceImpl implements NoteService {
     private final AssetRepository assetRepository;
     private final com.proovy.domain.user.repository.UserPlanRepository userPlanRepository;
     private final S3Service s3Service;
+    private final EmbeddingJobPublisher embeddingJobPublisher;
 
     @Override
     public CreateNoteResponse createNote(Long userId, CreateNoteRequest request) {
@@ -80,6 +83,9 @@ public class NoteServiceImpl implements NoteService {
                 .build();
         note = noteRepository.save(note);
         log.info("노트 생성 완료 - noteId: {}", note.getId());
+
+        String contentHash = HashUtils.sha256(note.getContentMd());
+        embeddingJobPublisher.publishEmbeddingJob(note.getId(), contentHash, "text-embedding-3-small");
 
         // 4. 응답 생성 (대화/메시지는 생성하지 않음)
         int conversationLimit = 50; // TODO: PlanType에 대화 제한 수가 추가되면 해당 값 사용

--- a/src/main/java/com/proovy/global/config/RedisConfig.java
+++ b/src/main/java/com/proovy/global/config/RedisConfig.java
@@ -4,8 +4,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -22,7 +24,13 @@ public class RedisConfig {
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(host);
+        config.setPort(port);
+
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
+        factory.setValidateConnection(true);
+        return factory;
     }
 
     @Bean
@@ -31,6 +39,15 @@ public class RedisConfig {
         template.setConnectionFactory(redisConnectionFactory());
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate() {
+        StringRedisTemplate template = new StringRedisTemplate();
+        template.setConnectionFactory(redisConnectionFactory());
         return template;
     }
 }

--- a/src/main/java/com/proovy/global/security/InternalApiTokenAuthenticationFilter.java
+++ b/src/main/java/com/proovy/global/security/InternalApiTokenAuthenticationFilter.java
@@ -1,0 +1,69 @@
+package com.proovy.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.proovy.global.response.ApiResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class InternalApiTokenAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String INTERNAL_PATH = "/internal";
+    private static final String INTERNAL_PATH_PREFIX = "/internal/";
+    private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+
+    private final ObjectMapper objectMapper;
+
+    @Value("${internal.api.token}")
+    private String internalApiToken;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getServletPath();
+        if (path == null) {
+            return true;
+        }
+        return !(INTERNAL_PATH.equals(path) || path.startsWith(INTERNAL_PATH_PREFIX));
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String requestToken = request.getHeader(INTERNAL_TOKEN_HEADER);
+        if (requestToken == null || !internalApiToken.equals(requestToken)) {
+            SecurityContextHolder.clearContext();
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            ApiResponse<?> errorResponse = ApiResponse.failure("INTERNAL4031", "유효하지 않은 내부 API 토큰입니다.");
+            response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+            return;
+        }
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(
+                        "internal-api",
+                        null,
+                        List.of(new SimpleGrantedAuthority("ROLE_INTERNAL"))
+                );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/proovy/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/proovy/global/security/JwtAuthenticationFilter.java
@@ -35,7 +35,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
+    private static final String INTERNAL_PATH = "/internal";
+    private static final String INTERNAL_PATH_PREFIX = "/internal/";
     public static final String JWT_ERROR_ATTRIBUTE = "jwtError";
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getServletPath();
+        if (path == null) {
+            return false;
+        }
+        return INTERNAL_PATH.equals(path) || path.startsWith(INTERNAL_PATH_PREFIX);
+    }
 
     @Override
     protected void doFilterInternal(

--- a/src/main/java/com/proovy/global/security/SecurityConfig.java
+++ b/src/main/java/com/proovy/global/security/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/api/auth/logout").authenticated()
                         .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/internal/**").permitAll()
                         .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**", "/v3/api-docs/**").permitAll()
                     .requestMatchers("/health", "/actuator/health").permitAll()
                     // 에러 디스패치(/error) 시에는 인증 필터가 개입하지 않도록 허용

--- a/src/main/java/com/proovy/global/security/SecurityConfig.java
+++ b/src/main/java/com/proovy/global/security/SecurityConfig.java
@@ -25,6 +25,7 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthFilter;
     private final JwtAuthenticationEntryPoint jwtAuthEntryPoint;
+    private final InternalApiTokenAuthenticationFilter internalApiTokenAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -40,7 +41,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/api/auth/logout").authenticated()
                         .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/internal/**").permitAll()
+                        .requestMatchers("/internal/**").authenticated()
                         .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**", "/v3/api-docs/**").permitAll()
                     .requestMatchers("/health", "/actuator/health").permitAll()
                     // 에러 디스패치(/error) 시에는 인증 필터가 개입하지 않도록 허용
@@ -48,6 +49,7 @@ public class SecurityConfig {
                         // 나머지는 인증 필요
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(internalApiTokenAuthenticationFilter, JwtAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }

--- a/src/main/java/com/proovy/global/util/HashUtils.java
+++ b/src/main/java/com/proovy/global/util/HashUtils.java
@@ -1,0 +1,33 @@
+package com.proovy.global.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public final class HashUtils {
+
+    private HashUtils() {
+    }
+
+    public static String sha256(String input) {
+        if (input == null || input.isEmpty()) {
+            return "";
+        }
+
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            return bytesToHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 algorithm not found", e);
+        }
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder result = new StringBuilder();
+        for (byte b : bytes) {
+            result.append(String.format("%02x", b));
+        }
+        return result.toString();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,6 +23,12 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+      timeout: 3000ms
+      lettuce:
+        pool:
+          max-active: 8
+          max-idle: 8
+          min-idle: 2
 
   mvc:
     async:
@@ -108,6 +114,20 @@ proovy:
     host: ${PROOVY_AI_HOST:https://api.proovy.ai.kr/ai}
   api:
     public-base-url: ${PROOVY_API_BASE_URL:}
+
+internal:
+  api:
+    token: ${INTERNAL_API_TOKEN:your-secure-random-token-change-this}
+    port: 8081
+
+embedding:
+  redis:
+    stream:
+      key: embedding_jobs
+      consumer-group: spring-publisher
+    lock:
+      prefix: emb:lock
+      ttl: 3600
 
 ---
 # ===============================

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -117,7 +117,7 @@ proovy:
 
 internal:
   api:
-    token: ${INTERNAL_API_TOKEN:your-secure-random-token-change-this}
+    token: ${INTERNAL_API_TOKEN}
     port: 8081
 
 embedding:

--- a/src/main/resources/db/migration/V17__create_note_embeddings.sql
+++ b/src/main/resources/db/migration/V17__create_note_embeddings.sql
@@ -1,0 +1,36 @@
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS note_embeddings (
+    id BIGSERIAL PRIMARY KEY,
+    note_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    content_hash VARCHAR(64) NOT NULL,
+    embedding_model VARCHAR(50) NOT NULL DEFAULT 'text-embedding-3-small',
+    vector vector(1536) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_note_embedding UNIQUE (note_id, embedding_model)
+);
+
+CREATE INDEX IF NOT EXISTS idx_note_embeddings_note_id ON note_embeddings(note_id);
+CREATE INDEX IF NOT EXISTS idx_note_embeddings_user_id ON note_embeddings(user_id);
+CREATE INDEX IF NOT EXISTS idx_note_embeddings_hash ON note_embeddings(content_hash);
+
+CREATE INDEX IF NOT EXISTS idx_note_embeddings_vector_cosine
+ON note_embeddings
+USING hnsw (vector vector_cosine_ops)
+WITH (m = 16, ef_construction = 64);
+
+CREATE OR REPLACE FUNCTION update_note_embedding_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_note_embedding_updated ON note_embeddings;
+CREATE TRIGGER trg_note_embedding_updated
+BEFORE UPDATE ON note_embeddings
+FOR EACH ROW
+EXECUTE FUNCTION update_note_embedding_timestamp();

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -11,3 +11,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+internal:
+  api:
+    token: test-internal-token


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #113 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

- Redis/내부 API/임베딩 큐 설정 추가  
- pgvector 임베딩 테이블/인덱스/트리거 마이그레이션 추가  
- Redis 설정 확장(RedisStandaloneConfiguration 기반)  
- 해시 유틸 추가(SHA-256)  
- 임베딩 도메인 추가  
- 임베딩 서비스/큐 발행자 추가  
- 내부 API 컨트롤러 추가(/internal/notes/...)  
- 노트 생성 시 임베딩 작업 발행 연동  
- 보안에서 내부 API 허용  

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 내부 API 인증은 `X-Internal-Token` 헤더로 동작합니다.
- 임베딩 벡터 저장은 pgvector `vector(1536)` 기반이며, HNSW 코사인 인덱스를 사용합니다.
- 노트 생성 시 Redis Stream(`embedding_jobs`)에 작업이 발행됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 노트 자동 임베딩 워크플로 추가: 새 노트 저장 시 임베딩 생성 작업이 게시됩니다.
  * 임베딩 관리 내부 API 추가: 임베딩 소스 조회 및 임베딩 업서트(생성/갱신) 엔드포인트 제공.
  * 임베딩 저장소 및 검색 인프라 추가: 벡터 컬럼, 코사인 인덱스 및 DB 마이그레이션 포함.
  * 내부 API 보안 토큰 인증 및 Redis 기반 작업 발행(중복 방지) 기능 추가.

* **Chores**
  * 환경 및 Redis 설정(내부 API 토큰, 스트림/잠금 설정 등) 추가 및 테스트 설정 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->