### PR TITLE
[Feat] ai 대화 api 멀티턴 적용

### DIFF
--- a/src/main/java/com/proovy/domain/conversation/dto/request/ConversationRequest.java
+++ b/src/main/java/com/proovy/domain/conversation/dto/request/ConversationRequest.java
@@ -16,6 +16,9 @@ import java.util.List;
 @Schema(description = "대화 생성 요청")
 public class ConversationRequest {
 
+    @Schema(description = "연결할 노트 ID (선택)", example = "123")
+    private Long noteId;
+
     @Schema(description = "사용자 질문/지시문", example = "이 문제를 풀어줘", required = true)
     @NotBlank(message = "질문 내용은 필수입니다.")
     private String text;

--- a/src/main/java/com/proovy/domain/conversation/service/ChatServiceImpl.java
+++ b/src/main/java/com/proovy/domain/conversation/service/ChatServiceImpl.java
@@ -9,6 +9,8 @@ import com.proovy.domain.conversation.dto.request.ConversationRequest;
 import com.proovy.domain.conversation.dto.request.ProovyAiRequest;
 import com.proovy.domain.conversation.dto.response.ConversationResponse;
 import com.proovy.domain.conversation.dto.response.ProovyAiStreamEvent;
+import com.proovy.domain.note.entity.Note;
+import com.proovy.domain.note.repository.NoteRepository;
 import com.proovy.domain.conversation.entity.ChatMessage;
 import com.proovy.domain.conversation.entity.ChatSession;
 import com.proovy.domain.conversation.entity.ChatSessionStatus;
@@ -47,6 +49,7 @@ public class ChatServiceImpl implements ChatService {
     private final MessageAttachmentRepository messageAttachmentRepository;
     private final UserRepository userRepository;
     private final AssetRepository assetRepository;
+    private final NoteRepository noteRepository;
     private final S3Service s3Service;
     private final WebClient webClient;
     private final ObjectMapper objectMapper;
@@ -79,7 +82,25 @@ public class ChatServiceImpl implements ChatService {
             validateFeatures(request.getChosenFeatures());
         }
 
-        // 3. ChatSession 조회 또는 생성 (사용자의 가장 최근 활성 세션 사용)
+        // 3. Note 기반 threadId 조회 또는 ChatSession 사용
+        Note note = null;
+        String threadIdToUse = null;
+
+        if (request.getNoteId() != null) {
+            // Note가 지정된 경우
+            note = noteRepository.findById(request.getNoteId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.NOTE4041));
+
+            // Note 소유자 검증
+            if (!note.getUser().getId().equals(userId)) {
+                throw new BusinessException(ErrorCode.NOTE4031);
+            }
+
+            threadIdToUse = note.getThreadId();
+            log.debug("[Chat] Note 기반 대화 - noteId: {}, threadId: {}", note.getId(), threadIdToUse);
+        }
+
+        // 4. ChatSession 조회 또는 생성 (Note 없이 대화하거나 메시지 저장용)
         ChatSession chatSession = chatSessionRepository
                 .findFirstByUserIdAndStatusOrderByCreatedAtDesc(userId, ChatSessionStatus.ACTIVE)
                 .orElseGet(() -> {
@@ -90,8 +111,17 @@ public class ChatServiceImpl implements ChatService {
                     return chatSessionRepository.save(newSession);
                 });
 
-        log.debug("[Chat] 사용 중인 ChatSession - id: {}, externalThreadId: {}",
-            chatSession.getId(), chatSession.getExternalThreadId());
+        // Note가 없는 경우 ChatSession의 threadId 사용
+        if (threadIdToUse == null && note == null) {
+            threadIdToUse = chatSession.getExternalThreadId();
+        }
+
+        log.debug("[Chat] 사용 중인 ChatSession - id: {}, externalThreadId: {}, threadIdToUse: {}",
+            chatSession.getId(), chatSession.getExternalThreadId(), threadIdToUse);
+
+        // Note 참조를 final로 캡처 (람다에서 사용)
+        final Note finalNote = note;
+        final String finalThreadIdToUse = threadIdToUse;
 
         // 4. 사용자 메시지 저장
         JsonNode userContentJson = buildUserContentJson(request);
@@ -124,7 +154,7 @@ public class ChatServiceImpl implements ChatService {
         // 7. Proovy-ai 요청 생성 (Proovy-ai StreamInput 스키마에 맞게 구성)
         ProovyAiRequest aiRequest = ProovyAiRequest.builder()
             .message(request.getText())
-            .threadId(chatSession.getExternalThreadId())
+            .threadId(finalThreadIdToUse)  // Note 또는 ChatSession의 threadId
             .userId(String.valueOf(userId))
             .filesUrl(filesUrl)
             .chosenFeatures(request.getChosenFeatures())
@@ -143,10 +173,23 @@ public class ChatServiceImpl implements ChatService {
 
                     // thread_id 업데이트 (payload 내부에 포함되는 경우)
                     if (data != null && data.containsKey("thread_id")) {
-                        String threadId = (String) data.get("thread_id");
-                        if (chatSession.getExternalThreadId() == null && threadId != null) {
-                            chatSession.updateExternalThreadId(threadId);
-                            chatSessionRepository.save(chatSession);
+                        String newThreadId = (String) data.get("thread_id");
+                        
+                        if (newThreadId != null) {
+                            if (finalNote != null) {
+                                // Note가 있으면 Note에 threadId 저장
+                                if (finalNote.getThreadId() == null) {
+                                    finalNote.updateThreadId(newThreadId);
+                                    noteRepository.save(finalNote);
+                                    log.debug("[Chat] Note에 threadId 저장 - noteId: {}, threadId: {}", finalNote.getId(), newThreadId);
+                                }
+                            } else {
+                                // Note가 없으면 ChatSession에 저장 (기존 로직)
+                                if (chatSession.getExternalThreadId() == null) {
+                                    chatSession.updateExternalThreadId(newThreadId);
+                                    chatSessionRepository.save(chatSession);
+                                }
+                            }
                         }
                     }
 

--- a/src/main/java/com/proovy/domain/note/entity/Note.java
+++ b/src/main/java/com/proovy/domain/note/entity/Note.java
@@ -39,6 +39,9 @@ public class Note {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @Column(name = "thread_id", unique = true, length = 100)
+    private String threadId;  // Proovy-ai와 연동할 대화 맥락 식별자
+
     @Builder
     public Note(User user, String title, String contentMd) {
         this.user = user;
@@ -52,5 +55,9 @@ public class Note {
 
     public void updateContent(String contentMd) {
         this.contentMd = contentMd;
+    }
+
+    public void updateThreadId(String threadId) {
+        this.threadId = threadId;
     }
 }

--- a/src/main/resources/db/migration/V7__add_thread_id_to_notes.sql
+++ b/src/main/resources/db/migration/V7__add_thread_id_to_notes.sql
@@ -1,0 +1,8 @@
+-- Note 테이블에 thread_id 컬럼 추가 (멀티턴 대화 지원)
+ALTER TABLE notes
+    ADD COLUMN thread_id VARCHAR(100) UNIQUE;
+
+-- 인덱스 생성 (thread_id로 조회 시 성능 향상)
+CREATE INDEX idx_notes_thread_id ON notes(thread_id);
+
+COMMENT ON COLUMN notes.thread_id IS 'Proovy-ai LangGraph checkpointer와 연동할 대화 맥락 식별자';


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #97 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [x] 📝 문서 수정 (Documentation)

## 📝 작업 내용

- note entity에 threadId 추가
- POST/api/conversations 에서 noteId가 request body에 포함되는 경우 threadId를 ai 서버에 전달
- noteId가 request body에 포함되지 않을 경우 ai에서 응답 받은 threadId를 저장

## 📸 스크린샷

- <img width="898" height="594" alt="{EC4D5548-2BB6-42E1-A71F-BAFE247AAA60}" src="https://github.com/user-attachments/assets/75c46738-808f-41e3-9a64-489fec35ffc9" />

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 노트에 대화를 연결할 수 있는 기능을 추가했습니다.
  * 노트 기반 대화 맥락 관리로 대화 추적 및 조직화가 개선되었습니다.
  * 대화 스레드가 노트와 연동되어 더 나은 컨텍스트 유지가 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->