### PR TITLE
[Fix] 검색 관련 api /conversation, /storage 수정

### DIFF
--- a/src/main/java/com/proovy/domain/conversation/repository/ConversationRepository.java
+++ b/src/main/java/com/proovy/domain/conversation/repository/ConversationRepository.java
@@ -82,28 +82,28 @@ public interface ConversationRepository extends JpaRepository<Conversation, Long
      */
     @Query(value = """
             SELECT DISTINCT c.* FROM conversations c
-            JOIN notes n ON c.note_id = n.id
-            JOIN messages m ON m.conversation_id = c.id
-            LEFT JOIN message_tools mt ON mt.message_id = m.id
+            JOIN notes n ON c.note_id = n.note_id
+            JOIN messages m ON m.conversation_id = c.conversation_id
+            LEFT JOIN message_tools mt ON mt.message_id = m.message_id
             WHERE n.user_id = :userId
               AND m.search_vector @@ plainto_tsquery('simple', :query)
-              AND (:noteId IS NULL OR n.id = :noteId)
-              AND (:toolCode IS NULL OR mt.tool_code = :toolCode)
-              AND (:startDate IS NULL OR DATE(c.created_at) >= :startDate)
-              AND (:endDate IS NULL OR DATE(c.created_at) <= :endDate)
+              AND (CAST(:noteId AS BIGINT) IS NULL OR n.note_id = CAST(:noteId AS BIGINT))
+              AND (CAST(:toolCode AS VARCHAR) IS NULL OR mt.tool_code = CAST(:toolCode AS VARCHAR))
+              AND (CAST(:startDate AS DATE) IS NULL OR DATE(c.created_at) >= CAST(:startDate AS DATE))
+              AND (CAST(:endDate AS DATE) IS NULL OR DATE(c.created_at) <= CAST(:endDate AS DATE))
             ORDER BY c.created_at DESC
             """,
             countQuery = """
-            SELECT COUNT(DISTINCT c.id) FROM conversations c
-            JOIN notes n ON c.note_id = n.id
-            JOIN messages m ON m.conversation_id = c.id
-            LEFT JOIN message_tools mt ON mt.message_id = m.id
+            SELECT COUNT(DISTINCT c.conversation_id) FROM conversations c
+            JOIN notes n ON c.note_id = n.note_id
+            JOIN messages m ON m.conversation_id = c.conversation_id
+            LEFT JOIN message_tools mt ON mt.message_id = m.message_id
             WHERE n.user_id = :userId
               AND m.search_vector @@ plainto_tsquery('simple', :query)
-              AND (:noteId IS NULL OR n.id = :noteId)
-              AND (:toolCode IS NULL OR mt.tool_code = :toolCode)
-              AND (:startDate IS NULL OR DATE(c.created_at) >= :startDate)
-              AND (:endDate IS NULL OR DATE(c.created_at) <= :endDate)
+              AND (CAST(:noteId AS BIGINT) IS NULL OR n.note_id = CAST(:noteId AS BIGINT))
+              AND (CAST(:toolCode AS VARCHAR) IS NULL OR mt.tool_code = CAST(:toolCode AS VARCHAR))
+              AND (CAST(:startDate AS DATE) IS NULL OR DATE(c.created_at) >= CAST(:startDate AS DATE))
+              AND (CAST(:endDate AS DATE) IS NULL OR DATE(c.created_at) <= CAST(:endDate AS DATE))
             """,
             nativeQuery = true)
     Page<Conversation> searchByFullText(
@@ -120,28 +120,28 @@ public interface ConversationRepository extends JpaRepository<Conversation, Long
      */
     @Query(value = """
             SELECT DISTINCT c.* FROM conversations c
-            JOIN notes n ON c.note_id = n.id
-            JOIN messages m ON m.conversation_id = c.id
-            LEFT JOIN message_tools mt ON mt.message_id = m.id
+            JOIN notes n ON c.note_id = n.note_id
+            JOIN messages m ON m.conversation_id = c.conversation_id
+            LEFT JOIN message_tools mt ON mt.message_id = m.message_id
             WHERE n.user_id = :userId
               AND m.content ILIKE '%' || :query || '%'
-              AND (:noteId IS NULL OR n.id = :noteId)
-              AND (:toolCode IS NULL OR mt.tool_code = :toolCode)
-              AND (:startDate IS NULL OR DATE(c.created_at) >= :startDate)
-              AND (:endDate IS NULL OR DATE(c.created_at) <= :endDate)
+              AND (CAST(:noteId AS BIGINT) IS NULL OR n.note_id = CAST(:noteId AS BIGINT))
+              AND (CAST(:toolCode AS VARCHAR) IS NULL OR mt.tool_code = CAST(:toolCode AS VARCHAR))
+              AND (CAST(:startDate AS DATE) IS NULL OR DATE(c.created_at) >= CAST(:startDate AS DATE))
+              AND (CAST(:endDate AS DATE) IS NULL OR DATE(c.created_at) <= CAST(:endDate AS DATE))
             ORDER BY c.created_at DESC
             """,
             countQuery = """
-            SELECT COUNT(DISTINCT c.id) FROM conversations c
-            JOIN notes n ON c.note_id = n.id
-            JOIN messages m ON m.conversation_id = c.id
-            LEFT JOIN message_tools mt ON mt.message_id = m.id
+            SELECT COUNT(DISTINCT c.conversation_id) FROM conversations c
+            JOIN notes n ON c.note_id = n.note_id
+            JOIN messages m ON m.conversation_id = c.conversation_id
+            LEFT JOIN message_tools mt ON mt.message_id = m.message_id
             WHERE n.user_id = :userId
               AND m.content ILIKE '%' || :query || '%'
-              AND (:noteId IS NULL OR n.id = :noteId)
-              AND (:toolCode IS NULL OR mt.tool_code = :toolCode)
-              AND (:startDate IS NULL OR DATE(c.created_at) >= :startDate)
-              AND (:endDate IS NULL OR DATE(c.created_at) <= :endDate)
+              AND (CAST(:noteId AS BIGINT) IS NULL OR n.note_id = CAST(:noteId AS BIGINT))
+              AND (CAST(:toolCode AS VARCHAR) IS NULL OR mt.tool_code = CAST(:toolCode AS VARCHAR))
+              AND (CAST(:startDate AS DATE) IS NULL OR DATE(c.created_at) >= CAST(:startDate AS DATE))
+              AND (CAST(:endDate AS DATE) IS NULL OR DATE(c.created_at) <= CAST(:endDate AS DATE))
             """,
             nativeQuery = true)
     Page<Conversation> searchByTrigram(

--- a/src/main/java/com/proovy/domain/note/repository/NoteRepository.java
+++ b/src/main/java/com/proovy/domain/note/repository/NoteRepository.java
@@ -28,6 +28,19 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
     List<Note> searchByTitleKeyword(@Param("userId") Long userId, @Param("keyword") String keyword);
 
     /**
+     * 노트 제목 또는 파일명으로 검색 (스토리지용)
+     */
+    @Query(value = """
+            SELECT DISTINCT n.* FROM notes n
+            LEFT JOIN assets a ON a.note_id = n.note_id
+            WHERE n.user_id = :userId
+              AND (LOWER(n.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                   OR LOWER(a.file_name) LIKE LOWER(CONCAT('%', :keyword, '%')))
+            ORDER BY n.created_at DESC
+            """, nativeQuery = true)
+    List<Note> searchByTitleOrFileName(@Param("userId") Long userId, @Param("keyword") String keyword);
+
+    /**
      * 사용자의 노트 목록 페이지네이션 조회
      */
     Page<Note> findByUserId(Long userId, Pageable pageable);

--- a/src/main/java/com/proovy/domain/storage/service/StorageService.java
+++ b/src/main/java/com/proovy/domain/storage/service/StorageService.java
@@ -114,10 +114,10 @@ public class StorageService {
         PlanType planType = userPlan != null ? userPlan.getPlanType() : PlanType.FREE;
         boolean isActive = userPlan != null ? userPlan.getIsActive() : true;
 
-        // 노트 목록 조회 (검색어 있으면 필터링)
+        // 노트 목록 조회 (검색어 있으면 노트 제목 또는 파일명으로 필터링)
         List<Note> notes;
         if (keyword != null && !keyword.isBlank()) {
-            notes = noteRepository.searchByTitleKeyword(userId, keyword);
+            notes = noteRepository.searchByTitleOrFileName(userId, keyword);
         } else {
             notes = noteRepository.findByUserIdOrderByCreatedAtDesc(userId);
         }

--- a/src/test/java/com/proovy/domain/storage/service/StorageServiceTest.java
+++ b/src/test/java/com/proovy/domain/storage/service/StorageServiceTest.java
@@ -129,7 +129,7 @@ class StorageServiceTest {
             String keyword = "테스트";
             given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
             given(userPlanRepository.findActiveByUserId(userId)).willReturn(Optional.of(freePlan));
-            given(noteRepository.searchByTitleKeyword(userId, keyword)).willReturn(List.of(testNote));
+            given(noteRepository.searchByTitleOrFileName(userId, keyword)).willReturn(List.of(testNote));
             given(assetRepository.findAllByUserId(userId)).willReturn(List.of(testAsset));
 
             // when


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #132 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

/api/conversations/search 500 오류 수정

Native Query에서 nullable 파라미터(noteId, toolCode, startDate, endDate) 사용 시 PostgreSQL 타입 추론 실패로 500 발생

searchByFullText, searchByTrigram 쿼리에 명시적 CAST 추가하여 null 파라미터도 타입이 확정되도록 수정

예) CAST(:noteId AS BIGINT), CAST(:startDate AS DATE) 등

스토리지 검색 기능 개선

기존: 노트 제목(title)로만 검색 → 파일명 검색 시 결과가 비어있음

변경: 노트 제목 OR 파일명(assets.file_name) 기준 검색 지원

NoteRepository.searchByTitleOrFileName(userId, keyword) 신규 추가

StorageService에서 검색 시 해당 메서드로 조회하도록 변경

프로덕션 502 방지용 Native Query 컬럼명 정합성 수정

실제 스키마 PK 컬럼명과 불일치하여 배포 시 502 발생 가능했던 부분 수정

수정 사항:

notes: n.id → n.note_id

conversations: c.id → c.conversation_id

messages: m.id → m.message_id

ConversationRepository / NoteRepository Native Query 전반 반영

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 대화 검색의 조인 및 필터 조건을 정확하게 개선해 검색 결과 신뢰성을 높였습니다.

* **새로운 기능**
  * 노트 검색 시 제목뿐 아니라 첨부 파일명으로도 검색할 수 있도록 확장했습니다.

* **테스트**
  * 키워드 검색 관련 테스트를 최신 검색 동작에 맞춰 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->