### PR TITLE
[Feat] confirmUpload 이미지 썸네일 동기 생성 및 asset 응답 thumbnailUrl 추가

### DIFF
--- a/src/main/java/com/proovy/domain/asset/controller/AssetsController.java
+++ b/src/main/java/com/proovy/domain/asset/controller/AssetsController.java
@@ -3,7 +3,6 @@ package com.proovy.domain.asset.controller;
 import com.proovy.domain.asset.dto.request.UploadUrlRequest;
 import com.proovy.domain.asset.dto.response.AssetDetailResponse;
 import com.proovy.domain.asset.dto.response.DownloadUrlResponse;
-import com.proovy.domain.asset.dto.response.UploadConfirmResponse;
 import com.proovy.domain.asset.dto.response.UploadUrlResponse;
 import com.proovy.domain.asset.service.AssetsService;
 import com.proovy.global.response.ApiResponse;
@@ -99,28 +98,28 @@ public class AssetsController {
             description = """
                     클라이언트가 S3에 파일 업로드를 완료한 후 서버에 알림을 보냅니다.
 
-                    이 API 호출로 OCR 처리가 시작됩니다.
+                    **이미지 파일**: 썸네일이 즉시 생성되어 응답에 포함됩니다.
+                    **PDF 파일**: 썸네일은 비동기로 생성됩니다 (완료 시 폴링 필요).
 
                     **주의사항**:
                     - 반드시 Presigned URL로 S3 업로드를 완료한 후 호출해야 합니다
                     - 중복 호출 시 409 Conflict 에러가 반환됩니다
-                    - OCR 처리는 비동기로 진행됩니다 (파일 크기에 따라 수초~수분 소요)
                     """
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "업로드 확인 완료, OCR 처리 시작"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "업로드 확인 완료 (이미지는 썸네일 URL 포함)"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "S3에 파일이 업로드되지 않음 (ASSET4007)"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 (AUTH4010, AUTH4012, AUTH4013)"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음 (ASSET4031)"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "자산을 찾을 수 없음 (ASSET4041)"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 확인된 자산 (ASSET4091)")
     })
-    public ApiResponse<UploadConfirmResponse> confirmUpload(
+    public ApiResponse<AssetDetailResponse> confirmUpload(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(description = "자산 ID", required = true)
             @PathVariable Long assetId) {
 
-        UploadConfirmResponse response = assetsService.confirmUpload(userPrincipal.getUserId(), assetId);
+        AssetDetailResponse response = assetsService.confirmUpload(userPrincipal.getUserId(), assetId);
         return ApiResponse.success("업로드가 확인되었습니다.", response);
     }
 

--- a/src/main/java/com/proovy/domain/asset/dto/response/AssetDetailResponse.java
+++ b/src/main/java/com/proovy/domain/asset/dto/response/AssetDetailResponse.java
@@ -34,6 +34,9 @@ public class AssetDetailResponse {
     @Schema(description = "MIME 타입", example = "application/pdf")
     private String mimeType;
 
+    @Schema(description = "썸네일 URL (이미지는 즉시 생성, PDF는 비동기 처리)")
+    private String thumbnailUrl;
+
     @Schema(description = "총 페이지 수 (PDF/PPT인 경우)", example = "12")
     private Integer totalPages;
 
@@ -77,6 +80,10 @@ public class AssetDetailResponse {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     public static AssetDetailResponse from(Asset asset) {
+        return from(asset, null);
+    }
+
+    public static AssetDetailResponse from(Asset asset, String thumbnailUrl) {
         AssetDetailResponseBuilder builder = AssetDetailResponse.builder()
                 .assetId(asset.getId())
                 .noteId(asset.getNoteId())
@@ -84,6 +91,7 @@ public class AssetDetailResponse {
                 .fileName(asset.getFileName())
                 .fileSize(asset.getFileSize())
                 .mimeType(asset.getMimeType())
+                .thumbnailUrl(thumbnailUrl)
                 .totalPages(asset.getTotalPages())
                 .ocrStatus(asset.getOcrStatus() != null ? asset.getOcrStatus().name() : null)
                 .ocrProcessedAt(asset.getOcrProcessedAt())

--- a/src/main/java/com/proovy/domain/asset/dto/response/UploadConfirmResponse.java
+++ b/src/main/java/com/proovy/domain/asset/dto/response/UploadConfirmResponse.java
@@ -30,6 +30,9 @@ public class UploadConfirmResponse {
     @Schema(description = "OCR 처리 상태", example = "processing")
     private String ocrStatus;
 
+    @Schema(description = "썸네일 S3 키 (이미지만 즉시 생성, PDF는 비동기 처리)", example = "users/1/notes/1/thumbnails/uuid_thumb.jpg")
+    private String thumbnailS3Key;
+
     @Schema(description = "생성 시각", example = "2025-01-05T10:00:00")
     private LocalDateTime createdAt;
 
@@ -41,6 +44,7 @@ public class UploadConfirmResponse {
                 .mimeType(asset.getMimeType())
                 .source(asset.getSource().name())
                 .ocrStatus(asset.getOcrStatus() != null ? asset.getOcrStatus().name() : null)
+                .thumbnailS3Key(asset.getThumbnailS3Key())
                 .createdAt(asset.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/proovy/domain/asset/entity/Asset.java
+++ b/src/main/java/com/proovy/domain/asset/entity/Asset.java
@@ -133,7 +133,10 @@ public class Asset {
      */
     public void updateThumbnail(String thumbnailS3Key) {
         this.thumbnailS3Key = thumbnailS3Key;
-        this.ocrStatus = OcrStatus.completed; // 썸네일 생성 완료 = OCR 처리 완료
-        this.ocrProcessedAt = LocalDateTime.now();
+        // 이미지 파일은 썸네일만 있으면 완료 (OCR 불필요)
+        if (this.ocrStatus == OcrStatus.processing) {
+            this.ocrStatus = OcrStatus.completed;
+            this.ocrProcessedAt = LocalDateTime.now();
+        }
     }
 }

--- a/src/main/java/com/proovy/domain/asset/service/AssetsService.java
+++ b/src/main/java/com/proovy/domain/asset/service/AssetsService.java
@@ -3,7 +3,6 @@ package com.proovy.domain.asset.service;
 import com.proovy.domain.asset.dto.request.UploadUrlRequest;
 import com.proovy.domain.asset.dto.response.AssetDetailResponse;
 import com.proovy.domain.asset.dto.response.DownloadUrlResponse;
-import com.proovy.domain.asset.dto.response.UploadConfirmResponse;
 import com.proovy.domain.asset.dto.response.UploadUrlResponse;
 
 public interface AssetsService {
@@ -25,12 +24,12 @@ public interface AssetsService {
     DownloadUrlResponse generateDownloadUrl(Long userId, Long assetId);
 
     /**
-     * S3 업로드 완료 확인 및 OCR 처리 시작
+     * S3 업로드 완료 확인 및 썸네일 생성
      * @param userId 사용자 ID
      * @param assetId 자산 ID
-     * @return 업로드 확인 결과
+     * @return 업로드 확인 결과 (썸네일 URL 포함)
      */
-    UploadConfirmResponse confirmUpload(Long userId, Long assetId);
+    AssetDetailResponse confirmUpload(Long userId, Long assetId);
 
     /**
      * 자산 상세 정보 + OCR 결과 조회
@@ -57,4 +56,11 @@ public interface AssetsService {
      * 타임아웃된 OCR 처리 자산들을 실패로 변경
      */
     void markTimedOutOcrAsFailed();
+
+    /**
+     * Asset 썸네일 정보 업데이트 (별도 트랜잭션)
+     * @param assetId 자산 ID
+     * @param thumbnailS3Key 썸네일 S3 키
+     */
+    void updateAssetThumbnail(Long assetId, String thumbnailS3Key);
 }

--- a/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
+++ b/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
@@ -225,13 +225,10 @@ public class AssetsServiceImpl implements AssetsService {
             try {
                 String thumbnailS3Key = thumbnailService.generateThumbnailSync(s3Key, mimeType);
                 if (thumbnailS3Key != null) {
-                    // 썸네일 생성 성공 - Asset 업데이트 (별도 트랜잭션)
-                    getSelf().updateAssetThumbnail(savedAssetId, thumbnailS3Key);
-                    log.info("[Asset] 이미지 썸네일 생성 완료 (동기) - assetId: {}", savedAssetId);
-
-                    // 썸네일 생성 후 최신 Asset 정보 다시 조회
-                    asset = assetRepository.findById(savedAssetId)
-                            .orElseThrow(() -> new BusinessException(ErrorCode.ASSET4041));
+                    // 썸네일 생성 성공 - 같은 트랜잭션 내에서 직접 업데이트
+                    asset.updateThumbnail(thumbnailS3Key);
+                    assetRepository.save(asset);
+                    log.info("[Asset] 이미지 썸네일 생성 완료 (동기) - assetId: {}, thumbnailS3Key: {}", savedAssetId, thumbnailS3Key);
                 } else {
                     log.warn("[Asset] 이미지 썸네일 생성 실패 - assetId: {}", savedAssetId);
                 }
@@ -249,7 +246,8 @@ public class AssetsServiceImpl implements AssetsService {
             });
         }
 
-        log.info("[Asset] 업로드 확인 완료 - assetId: {}, userId: {}", assetId, userId);
+        log.info("[Asset] 업로드 확인 완료 - assetId: {}, userId: {}, ocrStatus: {}",
+                assetId, userId, asset.getOcrStatus());
 
         // 썸네일 URL 생성 (있는 경우)
         String thumbnailUrl = asset.getThumbnailS3Key() != null

--- a/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
+++ b/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
@@ -4,7 +4,6 @@ import com.proovy.domain.asset.constant.AllowedMimeType;
 import com.proovy.domain.asset.dto.request.UploadUrlRequest;
 import com.proovy.domain.asset.dto.response.AssetDetailResponse;
 import com.proovy.domain.asset.dto.response.DownloadUrlResponse;
-import com.proovy.domain.asset.dto.response.UploadConfirmResponse;
 import com.proovy.domain.asset.dto.response.UploadUrlResponse;
 import com.proovy.domain.asset.entity.Asset;
 import com.proovy.domain.asset.entity.AssetStatus;
@@ -185,7 +184,7 @@ public class AssetsServiceImpl implements AssetsService {
 
     @Override
     @Transactional
-    public UploadConfirmResponse confirmUpload(Long userId, Long assetId) {
+    public AssetDetailResponse confirmUpload(Long userId, Long assetId) {
         // 1. Asset 존재 확인
         Asset asset = assetRepository.findById(assetId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ASSET4041));
@@ -216,21 +215,48 @@ public class AssetsServiceImpl implements AssetsService {
             throw new BusinessException(ErrorCode.ASSET4091);
         }
 
-        // 6. 썸네일 생성 (트랜잭션 커밋 후 비동기 실행)
+        // 6. 썸네일 생성
         final Long savedAssetId = asset.getId();
         final String s3Key = asset.getS3Key();
         final String mimeType = asset.getMimeType();
 
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                thumbnailService.generateThumbnailAsync(savedAssetId, s3Key, mimeType);
+        // 이미지 파일인 경우: 동기적으로 썸네일 생성 (빠른 응답)
+        if (mimeType.startsWith("image/")) {
+            try {
+                String thumbnailS3Key = thumbnailService.generateThumbnailSync(s3Key, mimeType);
+                if (thumbnailS3Key != null) {
+                    // 썸네일 생성 성공 - Asset 업데이트 (별도 트랜잭션)
+                    getSelf().updateAssetThumbnail(savedAssetId, thumbnailS3Key);
+                    log.info("[Asset] 이미지 썸네일 생성 완료 (동기) - assetId: {}", savedAssetId);
+
+                    // 썸네일 생성 후 최신 Asset 정보 다시 조회
+                    asset = assetRepository.findById(savedAssetId)
+                            .orElseThrow(() -> new BusinessException(ErrorCode.ASSET4041));
+                } else {
+                    log.warn("[Asset] 이미지 썸네일 생성 실패 - assetId: {}", savedAssetId);
+                }
+            } catch (Exception e) {
+                log.error("[Asset] 이미지 썸네일 생성 중 오류 - assetId: {}, error: {}", savedAssetId, e.getMessage(), e);
             }
-        });
+        }
+        // PDF 파일인 경우: 비동기로 썸네일 생성 (시간 소요)
+        else if (mimeType.equals("application/pdf")) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    thumbnailService.generateThumbnailAsync(savedAssetId, s3Key, mimeType);
+                }
+            });
+        }
 
         log.info("[Asset] 업로드 확인 완료 - assetId: {}, userId: {}", assetId, userId);
 
-        return UploadConfirmResponse.from(asset);
+        // 썸네일 URL 생성 (있는 경우)
+        String thumbnailUrl = asset.getThumbnailS3Key() != null
+                ? s3Service.getThumbnailUrl(asset.getThumbnailS3Key())
+                : null;
+
+        return AssetDetailResponse.from(asset, thumbnailUrl);
     }
 
     @Override
@@ -246,7 +272,12 @@ public class AssetsServiceImpl implements AssetsService {
 
         log.debug("[Asset] 자산 상세 조회 - assetId: {}, ocrStatus: {}", assetId, asset.getOcrStatus());
 
-        return AssetDetailResponse.from(asset);
+        // 썸네일 URL 생성 (있는 경우)
+        String thumbnailUrl = asset.getThumbnailS3Key() != null
+                ? s3Service.getThumbnailUrl(asset.getThumbnailS3Key())
+                : null;
+
+        return AssetDetailResponse.from(asset, thumbnailUrl);
     }
 
     @Override
@@ -328,5 +359,21 @@ public class AssetsServiceImpl implements AssetsService {
                         asset.getId(), asset.getUpdatedAt());
             }
         }
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateAssetThumbnail(Long assetId, String thumbnailS3Key) {
+        Asset asset = assetRepository.findById(assetId)
+                .orElseThrow(() -> {
+                    log.warn("[Asset] Asset 미존재로 썸네일 연결 실패 - assetId: {}, thumbnailS3Key: {}",
+                            assetId, thumbnailS3Key);
+                    return new BusinessException(ErrorCode.ASSET4041);
+                });
+
+        asset.updateThumbnail(thumbnailS3Key);
+        assetRepository.save(asset);
+        log.info("[Asset] Asset 썸네일 업데이트 완료 - assetId: {}, thumbnailS3Key: {}",
+                assetId, thumbnailS3Key);
     }
 }

--- a/src/main/java/com/proovy/global/infra/thumbnail/ThumbnailService.java
+++ b/src/main/java/com/proovy/global/infra/thumbnail/ThumbnailService.java
@@ -64,8 +64,47 @@ public class ThumbnailService {
     }
 
     /**
-     * 썸네일 생성 (비동기)
-     * - 이미지: 리사이즈
+     * 썸네일 생성 (동기) - 이미지 전용
+     * 빠른 응답을 위해 이미지는 동기적으로 처리
+     */
+    public String generateThumbnailSync(String s3Key, String mimeType) {
+        try {
+            log.info("[Thumbnail] 썸네일 생성 시작 (동기) - s3Key: {}, mimeType: {}", s3Key, mimeType);
+
+            if (!mimeType.startsWith("image/")) {
+                log.warn("[Thumbnail] 동기 처리는 이미지만 지원 - mimeType: {}", mimeType);
+                return null;
+            }
+
+            // 1. 원본 파일 다운로드 URL 생성
+            String fileUrl = s3Service.getFileUrl(s3Key);
+
+            // 2. 파일 다운로드
+            byte[] fileBytes = downloadFile(fileUrl);
+
+            // 3. 썸네일 생성
+            byte[] thumbnailBytes = createImageThumbnail(fileBytes);
+
+            // 4. 썸네일 S3 키 생성
+            String thumbnailS3Key = generateThumbnailS3Key(s3Key);
+
+            // 5. 썸네일 S3 업로드
+            try (InputStream thumbnailStream = new ByteArrayInputStream(thumbnailBytes)) {
+                s3Service.uploadFile(thumbnailS3Key, thumbnailStream,
+                        thumbnailBytes.length, "image/jpeg");
+            }
+
+            log.info("[Thumbnail] 썸네일 생성 완료 (동기) - thumbnailS3Key: {}", thumbnailS3Key);
+            return thumbnailS3Key;
+
+        } catch (Exception e) {
+            log.error("[Thumbnail] 썸네일 생성 실패 (동기) - s3Key: {}, error: {}", s3Key, e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * 썸네일 생성 (비동기) - PDF 전용
      * - PDF: 첫 페이지를 이미지로 변환 후 리사이즈
      */
     @Async


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #140 

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용
### 백엔드 개선사항
1) 이미지 썸네일 즉시 생성
- 이미지 파일은 `confirmUpload` API에서 동기적으로 썸네일 생성
- 응답에 `thumbnailUrl` 포함 → 업로드 직후 즉시 썸네일 표시

2) PDF 썸네일 비동기 유지
- PDF는 처리 시간이 길어 기존대로 비동기 처리

3) 응답 구조 개선
- `confirmUpload` → `AssetDetailResponse` 반환 (thumbnailUrl 포함)
- `getAssetDetail` 응답에도 thumbnailUrl 포함

### 수정된 파일
- `ThumbnailService.java` - 동기 썸네일 생성 메서드 추가
- `AssetsServiceImpl.java` - 이미지 동기 / PDF 비동기 분기 처리
- `AssetDetailResponse.java` - `thumbnailUrl` 필드 추가

## 📸 스크린샷

## ✅ 체크리스트
- [ ] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 코드 스타일 가이드를 준수했습니다
- [ ] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 자산 업로드 확인 시 축소판 URL을 포함한 상세 자산 정보를 반환합니다.
  * 이미지 파일의 축소판은 업로드 확인 후 즉시 생성되어 제공됩니다.
  * PDF 파일의 축소판은 백그라운드에서 비동기로 처리됩니다.
  * 자산 상세 조회 시 축소판 URL이 포함됩니다.

* **버그 수정**
  * 축소판만 생성된 경우 OCR 상태가 불필요하게 완료 처리되지 않도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->