### PR TITLE
[Fix] 썸네일 실패 fallback 및 ocrStatus 소문자 정규화

### DIFF
--- a/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
+++ b/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
@@ -224,14 +224,16 @@ public class AssetsServiceImpl implements AssetsService {
         if (mimeType.startsWith("image/")) {
             try {
                 String thumbnailS3Key = thumbnailService.generateThumbnailSync(s3Key, mimeType);
-                if (thumbnailS3Key != null) {
-                    // 썸네일 생성 성공 - 같은 트랜잭션 내에서 직접 업데이트
-                    asset.updateThumbnail(thumbnailS3Key);
-                    assetRepository.save(asset);
-                    log.info("[Asset] 이미지 썸네일 생성 완료 (동기) - assetId: {}, thumbnailS3Key: {}", savedAssetId, thumbnailS3Key);
-                } else {
-                    log.warn("[Asset] 이미지 썸네일 생성 실패 - assetId: {}", savedAssetId);
+                if (thumbnailS3Key == null) {
+                    // WEBP 등 디코딩 이슈가 있어도 이미지는 즉시 미리보기가 가능해야 하므로 원본을 fallback으로 사용
+                    thumbnailS3Key = s3Key;
+                    log.warn("[Asset] 이미지 썸네일 생성 실패 - 원본 fallback 사용 - assetId: {}, mimeType: {}", savedAssetId, mimeType);
                 }
+
+                // 썸네일 생성 성공 또는 fallback - 같은 트랜잭션 내에서 직접 업데이트
+                asset.updateThumbnail(thumbnailS3Key);
+                assetRepository.save(asset);
+                log.info("[Asset] 이미지 썸네일 생성 완료 (동기) - assetId: {}, thumbnailS3Key: {}", savedAssetId, thumbnailS3Key);
             } catch (Exception e) {
                 log.error("[Asset] 이미지 썸네일 생성 중 오류 - assetId: {}, error: {}", savedAssetId, e.getMessage(), e);
             }
@@ -310,7 +312,7 @@ public class AssetsServiceImpl implements AssetsService {
                 }
 
                 // S3 썸네일 삭제 (있는 경우)
-                if (thumbnailS3Key != null) {
+                if (thumbnailS3Key != null && !thumbnailS3Key.equals(s3Key)) {
                     try {
                         s3Service.deleteFile(thumbnailS3Key);
                         log.info("[Asset] S3 썸네일 삭제 완료 - s3Key: {}", thumbnailS3Key);

--- a/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
+++ b/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
@@ -467,7 +467,7 @@ public class NoteServiceImpl implements NoteService {
                             .fileName(asset.getFileName())
                             .fileType(category.getValue().toUpperCase())
                             .fileSize(asset.getFileSize())
-                            .ocrStatus(asset.getOcrStatus() != null ? asset.getOcrStatus().name().toUpperCase() : "PENDING")
+                            .ocrStatus(asset.getOcrStatus() != null ? asset.getOcrStatus().name().toLowerCase() : "pending")
                             .thumbnailUrl(thumbnailUrl)
                             .createdAt(asset.getCreatedAt())
                             .build();
@@ -621,7 +621,7 @@ public class NoteServiceImpl implements NoteService {
                             .mimeType(asset.getMimeType())
                             .fileType(category.getValue().toUpperCase())
                             .source(asset.getSource().name().toUpperCase())
-                            .ocrStatus(asset.getOcrStatus() != null ? asset.getOcrStatus().name().toUpperCase() : "PENDING")
+                            .ocrStatus(asset.getOcrStatus() != null ? asset.getOcrStatus().name().toLowerCase() : "pending")
                             .thumbnailUrl(thumbnailUrl)
                             .createdAt(asset.getCreatedAt())
                             .build();


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #142 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

  - DB 스키마/엔티티 컬럼/Enum 변경 없음 (서비스 로직 수정 범위)
- 썸네일 생성 실패 fallback 추가로 processing 고착 방지
  - `AssetsServiceImpl.java` 관련 구간 보완
- 노트 상세/에셋 목록의 `ocrStatus`를 소문자로 통일
  - 저장소/노트 화면 상태 불일치 해소

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 자산 이미지 썸네일 생성 실패 시 폴백 로직 추가로 파일 손실 방지
* 자산 삭제 중 원본 파일과 썸네일이 동일한 경우 원본 파일이 실수로 삭제되는 문제 해결

## 개선 사항
* OCR 상태 표시 형식 개선 (대문자에서 소문자로 변경)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->