### PR TITLE
[Fix] ocr assetId 문제 로그 private 문제 해결

### DIFF
--- a/src/main/java/com/proovy/domain/conversation/service/ChatServiceImpl.java
+++ b/src/main/java/com/proovy/domain/conversation/service/ChatServiceImpl.java
@@ -400,8 +400,10 @@ public class ChatServiceImpl implements ChatService {
 
         List<String> urls = assets.stream()
                 .map(asset -> {
-                    String url = s3Service.getFileUrl(asset.getS3Key());
-                    log.info("[Chat] S3 URL 생성 - assetId: {}, s3Key: {}, url: {}",
+                    // Presigned URL 생성 (15분 유효)
+                    String url = s3Service.generatePresignedDownloadUrl(
+                            asset.getS3Key(), asset.getFileName(), 15);
+                    log.info("[Chat] Presigned URL 생성 - assetId: {}, s3Key: {}, url: {}",
                             asset.getId(), asset.getS3Key(), url);
                     return url;
                 })


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #144 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- S3 버킷이 private이라서 AI 서버가 일반 URL로 파일에 접근할 수 없음 (403 Forbidden) 문제 해결

getFileUrl() → generatePresignedDownloadUrl() 변경

  // Before (403 에러)
  String url = s3Service.getFileUrl(asset.getS3Key());

  // After (인증된 URL, 15분 유효)
  String url = s3Service.generatePresignedDownloadUrl(
          asset.getS3Key(), asset.getFileName(), 15);

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [ ] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 자산 다운로드 URL 보안 강화: 직접 S3 URL 대신 15분 동안만 유효한 제한된 접근 URL을 사용합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->