### PR TITLE
[Fix] 스토리지 파일명 검색 시 매칭 파일만 노출하도록 수정

### DIFF
--- a/src/main/java/com/proovy/domain/storage/service/StorageService.java
+++ b/src/main/java/com/proovy/domain/storage/service/StorageService.java
@@ -139,16 +139,11 @@ public class StorageService {
                 .map(note -> {
                     List<Asset> noteAssets = assetsByNoteId.getOrDefault(note.getId(), List.of());
 
-                    // 노트별 사용량 계산 (최소 1MB로 반올림)
-                    long noteUsedBytes = noteAssets.stream()
-                            .mapToLong(Asset::getFileSize)
-                            .sum();
-                    // 0바이트가 아니면 최소 1MB로 표시, 아니면 반올림
-                    int noteUsedMb = noteUsedBytes == 0 ? 0 :
-                            Math.max(1, (int) Math.round((double) noteUsedBytes / (1024 * 1024)));
-
                     // 자산 DTO 변환 (썸네일 URL 생성 포함)
                     List<AssetSummaryDto> assetDtos = noteAssets.stream()
+                            // 검색어가 있으면 파일명으로 필터링
+                            .filter(asset -> keyword == null || keyword.isBlank() ||
+                                    asset.getFileName().toLowerCase().contains(keyword.toLowerCase()))
                             .map(asset -> {
                                 // S3Service 인터페이스에 정의된 썸네일 URL 생성 메서드 사용
                                 String thumbnailUrl = s3Service.getThumbnailUrl(asset.getThumbnailS3Key());
@@ -156,8 +151,21 @@ public class StorageService {
                             })
                             .toList();
 
+                    // 노트별 사용량 계산 (필터링된 파일 기준)
+                    long noteUsedBytes = noteAssets.stream()
+                            // 검색어가 있으면 파일명으로 필터링
+                            .filter(asset -> keyword == null || keyword.isBlank() ||
+                                    asset.getFileName().toLowerCase().contains(keyword.toLowerCase()))
+                            .mapToLong(Asset::getFileSize)
+                            .sum();
+                    // 0바이트가 아니면 최소 1MB로 표시, 아니면 반올림
+                    int noteUsedMb = noteUsedBytes == 0 ? 0 :
+                            Math.max(1, (int) Math.round((double) noteUsedBytes / (1024 * 1024)));
+
                     return NoteStorageDto.of(note.getId(), note.getTitle(), noteUsedMb, assetDtos);
                 })
+                // 검색어가 있을 때는 파일이 있는 노트만 표시
+                .filter(noteDto -> keyword == null || keyword.isBlank() || !noteDto.assets().isEmpty())
                 .toList();
 
         return StorageResponse.of(

--- a/src/test/java/com/proovy/domain/storage/service/StorageServiceTest.java
+++ b/src/test/java/com/proovy/domain/storage/service/StorageServiceTest.java
@@ -122,11 +122,11 @@ class StorageServiceTest {
         }
 
         @Test
-        @DisplayName("성공 - 검색어로 노트를 필터링한다")
+        @DisplayName("성공 - 검색어로 파일명을 필터링한다")
         void successWithKeyword() {
             // given
             Long userId = 1L;
-            String keyword = "테스트";
+            String keyword = "test";
             given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
             given(userPlanRepository.findActiveByUserId(userId)).willReturn(Optional.of(freePlan));
             given(noteRepository.searchByTitleOrFileName(userId, keyword)).willReturn(List.of(testNote));
@@ -138,6 +138,7 @@ class StorageServiceTest {
             // then
             assertThat(response).isNotNull();
             assertThat(response.notes()).hasSize(1);
+            assertThat(response.notes().getFirst().assets()).hasSize(1);
         }
 
         @Test


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #147 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 스토리지 파일명 검색(keyword) 동작 수정
  - 기존: 파일명으로 검색 시, 해당 파일이 포함된 노트의 모든 파일이 노출됨
  - 수정:
    1) 검색어가 있을 때 파일명에 검색어가 포함된 파일만 필터링하여 노출
    2) 노트별 용량을 **필터링된 파일 기준**으로 재계산
    3) 검색 결과에 파일이 없는 노트는 리스트에서 제외
  - 검색은 대소문자 구분 없이 처리(toLowerCase)

- 검색어가 없을 때는 기존과 동일하게 전체 노트/파일을 노출

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항
  - keyword 없는 경우 기존 동작 유지
  - keyword 있는 경우 매칭 파일만 노출되고 용량도 매칭 파일 기준인지
  - 매칭 파일이 없는 노트가 결과에서 제외되는지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 키워드 기반 필터링이 자산 수준과 노트별 집계에 일관되게 적용되도록 개선하여 스토리지 사용량이 검색 결과에 맞게 올바르게 표시됩니다. 키워드가 있을 때 자산이 없는 노트는 결과에서 제외됩니다.
* **테스트**
  * 파일명 필터링 관련 테스트를 갱신하고, 필터링 시 노트의 자산 포함 여부를 검증하는 단언을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->