### PR TITLE
[Fix] 구독 취소 예약 상태에서 회원탈퇴 허용

### DIFF
--- a/src/main/java/com/proovy/domain/user/service/UserService.java
+++ b/src/main/java/com/proovy/domain/user/service/UserService.java
@@ -147,9 +147,16 @@ public class UserService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER4041));
 
         // 2. 활성 구독 확인 (FREE가 아닌 플랜이 활성 상태면 탈퇴 불가)
+        // 단, 취소 예약이 걸려있으면(canceledAt != null && nextPlanType == FREE) 탈퇴 허용
         Optional<UserPlan> activePlan = userPlanRepository.findActiveByUserId(userId);
         if (activePlan.isPresent() && activePlan.get().getPlanType() != PlanType.FREE) {
-            throw new BusinessException(ErrorCode.USER4006);
+            UserPlan plan = activePlan.get();
+            // 취소 예약 상태가 아니면 탈퇴 불가
+            boolean isCancelScheduled = plan.getCanceledAt() != null &&
+                                         plan.getNextPlanType() == PlanType.FREE;
+            if (!isCancelScheduled) {
+                throw new BusinessException(ErrorCode.USER4006);
+            }
         }
 
         // 3. 사용자 관련 데이터 삭제


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #149 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 회원탈퇴 시 구독 상태 확인 로직 수정 (`UserService.java:149-160`)
  - 기존: FREE가 아닌 활성 플랜이 있으면 무조건 탈퇴 불가
  - 변경:
    - FREE가 아닌 활성 플랜이 있어도 **취소 예약 상태**면 탈퇴 허용
      - 조건: `canceledAt != null && nextPlanType == FREE`
    - 취소 예약이 없는 일반 유료 플랜 활성 상태에서만 탈퇴 불가 유지

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

  1) FREE 플랜 사용자 → 회원탈퇴 가능
  2) 유료 플랜 활성(취소 예약 없음) → 회원탈퇴 불가
  3) 유료 플랜 취소 예약(canceledAt 존재 + nextPlanType=FREE) → 회원탈퇴 가능


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 활성 요금제가 있는 사용자 계정 삭제 프로세스 개선: 취소가 예약된 경우 계정 삭제 허용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->