### PR TITLE
[Feat] 플랜 기반 크레딧 한도/월간 크레딧 부여 및 히스토리 기록

### DIFF
--- a/src/main/java/com/proovy/domain/auth/service/AuthService.java
+++ b/src/main/java/com/proovy/domain/auth/service/AuthService.java
@@ -242,7 +242,7 @@ public class AuthService {
         User savedUser = userRepository.save(user);
         log.info("신규 유저 가입 완료, userId: {}, provider: {}, createdAt: {}", savedUser.getId(), provider, savedUser.getCreatedAt());
 
-        // 3-1. 크레딧 잔액 초기화 (일일 100 + 가입 보너스 100)
+        // 3-1. 크레딧 잔액 초기화 (일일 100 크레딧)
         try {
             creditBalanceService.createSignupBalance(savedUser);
             log.info("크레딧 잔액 초기화 완료, userId: {}", savedUser.getId());
@@ -273,7 +273,7 @@ public class AuthService {
         return SignupCompleteResponse.builder()
                 .user(userDto)
                 .token(tokens)
-                .welcomeCredit(100)
+                .welcomeCredit(0)  // 가입 보너스 없음
                 .build();
     }
 

--- a/src/main/java/com/proovy/domain/credit/entity/CreditBalance.java
+++ b/src/main/java/com/proovy/domain/credit/entity/CreditBalance.java
@@ -122,6 +122,20 @@ public class CreditBalance {
         this.dailyExpiresAt = nextExpiry;
     }
 
+    // 일일 크레딧 한도 업데이트 (플랜 변경 시)
+    public void updateDailyLimit(int newLimit) {
+        this.dailyFreeLimit = newLimit;
+        // 현재 잔액이 새 한도를 초과하면 조정
+        if (this.dailyFreeCredit > newLimit) {
+            this.dailyFreeCredit = newLimit;
+        }
+    }
+
+    // 유료 크레딧 만료일 설정
+    public void setPaidExpiresAt(LocalDateTime expiresAt) {
+        this.paidExpiresAt = expiresAt;
+    }
+
     // 만료 처리
     public void expirePaidCredit() {
         this.paidCredit = 0;

--- a/src/main/java/com/proovy/domain/credit/service/CreditBalanceCreator.java
+++ b/src/main/java/com/proovy/domain/credit/service/CreditBalanceCreator.java
@@ -2,7 +2,9 @@ package com.proovy.domain.credit.service;
 
 import com.proovy.domain.credit.entity.CreditBalance;
 import com.proovy.domain.credit.repository.CreditBalanceRepository;
+import com.proovy.domain.user.entity.PlanType;
 import com.proovy.domain.user.entity.User;
+import com.proovy.domain.user.repository.UserPlanRepository;
 import com.proovy.domain.user.repository.UserRepository;
 import com.proovy.global.exception.BusinessException;
 import com.proovy.global.response.ErrorCode;
@@ -19,16 +21,22 @@ public class CreditBalanceCreator {
 
     private final CreditBalanceRepository creditBalanceRepository;
     private final UserRepository userRepository;
+    private final UserPlanRepository userPlanRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public CreditBalance createInitialBalance(Long userId, int freeCredit) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER4041));
 
+        // 현재 플랜의 dailyCreditLimit 조회
+        PlanType planType = userPlanRepository.findActivePlanTypeByUserId(userId)
+                .orElse(PlanType.FREE);
+        int dailyCreditLimit = planType.getDailyCreditLimit();
+
         CreditBalance balance = CreditBalance.builder()
                 .user(user)
-                .dailyFreeCredit(100)
-                .dailyFreeLimit(100)
+                .dailyFreeCredit(dailyCreditLimit)
+                .dailyFreeLimit(dailyCreditLimit)
                 .dailyExpiresAt(LocalDate.now().plusDays(1).atStartOfDay())
                 .freeCredit(freeCredit)
                 .paidCredit(0)

--- a/src/main/java/com/proovy/domain/credit/service/CreditBalanceService.java
+++ b/src/main/java/com/proovy/domain/credit/service/CreditBalanceService.java
@@ -48,36 +48,19 @@ public class CreditBalanceService {
 
     @Transactional
     public CreditBalance createSignupBalance(User user) {
-        // FREE 플랜의 dailyCreditLimit 사용
+        // FREE 플랜의 dailyCreditLimit 사용 (100)
         int dailyCreditLimit = PlanType.FREE.getDailyCreditLimit();
-        int signupBonus = 100;
 
         CreditBalance balance = CreditBalance.builder()
                 .user(user)
                 .dailyFreeCredit(dailyCreditLimit)
                 .dailyFreeLimit(dailyCreditLimit)
                 .dailyExpiresAt(LocalDate.now().plusDays(1).atStartOfDay())
-                .freeCredit(signupBonus)
-                .paidCredit(0)
+                .freeCredit(0)  // 가입 보너스 없음
+                .paidCredit(0)  // FREE 플랜은 월간 크레딧 없음
                 .build();
-        CreditBalance savedBalance = creditBalanceRepository.save(balance);
 
-        // 가입 보너스 히스토리 기록
-        CreditHistory history = CreditHistory.builder()
-                .user(user)
-                .eventType(CreditEventType.SIGNUP_BONUS)
-                .eventName("가입 보너스")
-                .description("회원가입 축하 크레딧")
-                .amount(signupBonus)
-                .changeType(CreditChangeType.EARN)
-                .creditType(CreditType.FREE)
-                .balanceAfterDaily(savedBalance.getDailyFreeCredit())
-                .balanceAfterFree(savedBalance.getFreeCredit())
-                .balanceAfterPaid(savedBalance.getPaidCredit())
-                .build();
-        creditHistoryRepository.save(history);
-
-        return savedBalance;
+        return creditBalanceRepository.save(balance);
     }
 
     /**

--- a/src/main/java/com/proovy/domain/credit/service/CreditBalanceService.java
+++ b/src/main/java/com/proovy/domain/credit/service/CreditBalanceService.java
@@ -1,7 +1,9 @@
 package com.proovy.domain.credit.service;
 
-import com.proovy.domain.credit.entity.CreditBalance;
+import com.proovy.domain.credit.entity.*;
 import com.proovy.domain.credit.repository.CreditBalanceRepository;
+import com.proovy.domain.credit.repository.CreditHistoryRepository;
+import com.proovy.domain.user.entity.PlanType;
 import com.proovy.domain.user.entity.User;
 import com.proovy.global.exception.BusinessException;
 import com.proovy.global.response.ErrorCode;
@@ -12,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Slf4j
 @Service
@@ -20,6 +23,7 @@ public class CreditBalanceService {
 
     private final CreditBalanceRepository creditBalanceRepository;
     private final CreditBalanceCreator creditBalanceCreator;
+    private final CreditHistoryRepository creditHistoryRepository;
 
     @Transactional
     public CreditBalance getOrCreateBalance(Long userId) {
@@ -44,15 +48,84 @@ public class CreditBalanceService {
 
     @Transactional
     public CreditBalance createSignupBalance(User user) {
+        // FREE 플랜의 dailyCreditLimit 사용
+        int dailyCreditLimit = PlanType.FREE.getDailyCreditLimit();
+        int signupBonus = 100;
+
         CreditBalance balance = CreditBalance.builder()
                 .user(user)
-                .dailyFreeCredit(100)
-                .dailyFreeLimit(100)
+                .dailyFreeCredit(dailyCreditLimit)
+                .dailyFreeLimit(dailyCreditLimit)
                 .dailyExpiresAt(LocalDate.now().plusDays(1).atStartOfDay())
-                .freeCredit(100)
+                .freeCredit(signupBonus)
                 .paidCredit(0)
                 .build();
-        return creditBalanceRepository.save(balance);
+        CreditBalance savedBalance = creditBalanceRepository.save(balance);
+
+        // 가입 보너스 히스토리 기록
+        CreditHistory history = CreditHistory.builder()
+                .user(user)
+                .eventType(CreditEventType.SIGNUP_BONUS)
+                .eventName("가입 보너스")
+                .description("회원가입 축하 크레딧")
+                .amount(signupBonus)
+                .changeType(CreditChangeType.EARN)
+                .creditType(CreditType.FREE)
+                .balanceAfterDaily(savedBalance.getDailyFreeCredit())
+                .balanceAfterFree(savedBalance.getFreeCredit())
+                .balanceAfterPaid(savedBalance.getPaidCredit())
+                .build();
+        creditHistoryRepository.save(history);
+
+        return savedBalance;
+    }
+
+    /**
+     * 월간 구독 크레딧 부여 (플랜 변경/갱신 시 호출)
+     */
+    @Transactional
+    public void grantMonthlyCredit(Long userId, PlanType planType) {
+        if (planType == PlanType.FREE) {
+            return; // FREE 플랜은 월간 크레딧 없음
+        }
+
+        CreditBalance balance = getOrCreateBalanceForUpdate(userId);
+        int monthlyCredit = planType.getMonthlyCreditLimit();
+        int dailyCreditLimit = planType.getDailyCreditLimit();
+
+        // 1. Monthly Credit 부여
+        balance.addPaidCredit(monthlyCredit);
+
+        // 2. Daily Limit 업데이트
+        if (balance.getDailyFreeLimit() != dailyCreditLimit) {
+            log.info("플랜 변경으로 일일 크레딧 한도 변경: userId={}, {} -> {}",
+                    userId, balance.getDailyFreeLimit(), dailyCreditLimit);
+            balance.updateDailyLimit(dailyCreditLimit);
+            balance.resetDailyCredit(LocalDate.now().plusDays(1).atStartOfDay());
+        }
+
+        // 3. Paid Credit 만료일 설정 (1개월 후)
+        LocalDateTime expiresAt = LocalDateTime.now().plusMonths(1);
+        balance.setPaidExpiresAt(expiresAt);
+
+        creditBalanceRepository.save(balance);
+
+        // 4. 히스토리 기록
+        CreditHistory history = CreditHistory.builder()
+                .user(balance.getUser())
+                .eventType(CreditEventType.MONTHLY_GRANT)
+                .eventName(planType.getDisplayName() + " 플랜 구독 크레딧")
+                .description(planType.getDisplayName() + " 플랜 월간 크레딧 " + monthlyCredit + " 지급")
+                .amount(monthlyCredit)
+                .changeType(CreditChangeType.EARN)
+                .creditType(CreditType.PAID)
+                .balanceAfterDaily(balance.getDailyFreeCredit())
+                .balanceAfterFree(balance.getFreeCredit())
+                .balanceAfterPaid(balance.getPaidCredit())
+                .build();
+        creditHistoryRepository.save(history);
+
+        log.info("월간 크레딧 부여 완료: userId={}, planType={}, amount={}", userId, planType, monthlyCredit);
     }
 
     private void createInitialBalanceSafely(Long userId, int freeCredit) {

--- a/src/main/java/com/proovy/domain/user/service/SubscriptionService.java
+++ b/src/main/java/com/proovy/domain/user/service/SubscriptionService.java
@@ -1,5 +1,6 @@
 package com.proovy.domain.user.service;
 
+import com.proovy.domain.credit.service.CreditBalanceService;
 import com.proovy.domain.user.dto.request.UpgradePlanRequest;
 import com.proovy.domain.user.dto.response.SubscriptionResponse;
 import com.proovy.domain.user.entity.PlanType;
@@ -36,6 +37,7 @@ public class SubscriptionService {
     private final UserRepository userRepository;
     private final UserPlanRepository userPlanRepository;
     private final PlatformTransactionManager transactionManager;
+    private final CreditBalanceService creditBalanceService;
 
     @Transactional
     public SubscriptionResponse getSubscription(Long userId) {
@@ -133,6 +135,12 @@ public class SubscriptionService {
             UserPlan newPlan = buildNextActivePlan(user, targetPlan, startedAt);
             UserPlan savedPlan = userPlanRepository.save(newPlan);
             userPlanRepository.flush();
+
+            // 유료 플랜으로 변경 시 월간 크레딧 부여
+            if (targetPlan != PlanType.FREE) {
+                creditBalanceService.grantMonthlyCredit(user.getId(), targetPlan);
+            }
+
             return SubscriptionResponse.from(savedPlan);
         } catch (DataIntegrityViolationException e) {
             log.warn("동시 플랜 변경 충돌 감지: userId={}, requestedPlan={}", user.getId(), targetPlan, e);
@@ -183,6 +191,11 @@ public class SubscriptionService {
 
         UserPlan nextPlan = buildNextActivePlan(duePlan.getUser(), nextPlanType, transitionAt);
         userPlanRepository.save(nextPlan);
+
+        // 유료 플랜으로 전환 시 월간 크레딧 부여
+        if (nextPlanType != PlanType.FREE) {
+            creditBalanceService.grantMonthlyCredit(duePlan.getUser().getId(), nextPlanType);
+        }
     }
 
     private boolean processDuePlanTransitionInNewTransaction(Long duePlanId, LocalDateTime now) {

--- a/src/main/java/com/proovy/domain/user/service/UserService.java
+++ b/src/main/java/com/proovy/domain/user/service/UserService.java
@@ -6,8 +6,10 @@ import com.proovy.domain.auth.service.AccessTokenBlacklistService;
 import com.proovy.domain.conversation.repository.ChatMessageRepository;
 import com.proovy.domain.conversation.repository.ChatSessionRepository;
 import com.proovy.domain.conversation.repository.MessageAttachmentRepository;
+import com.proovy.domain.credit.entity.CreditBalance;
 import com.proovy.domain.credit.repository.CreditBalanceRepository;
 import com.proovy.domain.credit.repository.CreditHistoryRepository;
+import com.proovy.domain.credit.service.CreditBalanceService;
 import com.proovy.domain.note.repository.NoteRepository;
 import com.proovy.domain.user.dto.response.DeleteUserResponse;
 import com.proovy.domain.user.dto.response.MyProfileResponse;
@@ -46,6 +48,7 @@ public class UserService {
     private final NoteRepository noteRepository;
     private final CreditBalanceRepository creditBalanceRepository;
     private final CreditHistoryRepository creditHistoryRepository;
+    private final CreditBalanceService creditBalanceService;
     private final MessageAttachmentRepository messageAttachmentRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final ChatSessionRepository chatSessionRepository;
@@ -88,27 +91,35 @@ public class UserService {
     }
 
     private CreditDto getCreditInfo(Long userId) {
-        // TODO: Credit 도메인 구현 후 실제 데이터로 교체
+        // 실제 크레딧 잔액 조회
+        CreditBalance balance = creditBalanceService.getOrCreateBalance(userId);
         PlanType planType = userPlanRepository.findActivePlanTypeByUserId(userId)
                 .orElse(PlanType.FREE);
-        LocalDateTime tomorrow = LocalDate.now().plusDays(1).atStartOfDay();
 
         DailyCreditDto dailyCredit = DailyCreditDto.builder()
-                .balance(100)
-                .limit(100)
-                .resetsAt(tomorrow.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                .balance(balance.getDailyFreeCredit())
+                .limit(balance.getDailyFreeLimit())
+                .resetsAt(balance.getDailyExpiresAt() != null
+                        ? balance.getDailyExpiresAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                        : LocalDate.now().plusDays(1).atStartOfDay().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
                 .build();
 
+        // monthlyCredit = freeCredit + paidCredit
+        int monthlyBalance = balance.getFreeCredit() + balance.getPaidCredit();
+        int monthlyLimit = planType.getMonthlyCreditLimit();
+
         MonthlyCreditDto monthlyCredit = MonthlyCreditDto.builder()
-                .balance(planType.getMonthlyCreditLimit())
-                .limit(planType.getMonthlyCreditLimit())
-                .expiresAt(null)
+                .balance(monthlyBalance)
+                .limit(monthlyLimit)
+                .expiresAt(balance.getPaidExpiresAt() != null
+                        ? balance.getPaidExpiresAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                        : null)
                 .build();
 
         return CreditDto.builder()
                 .dailyCredit(dailyCredit)
                 .monthlyCredit(monthlyCredit)
-                .totalAvailable(dailyCredit.balance() + monthlyCredit.balance())
+                .totalAvailable(balance.getTotalAvailable())
                 .build();
     }
 

--- a/src/main/java/com/proovy/domain/user/service/UserService.java
+++ b/src/main/java/com/proovy/domain/user/service/UserService.java
@@ -96,6 +96,7 @@ public class UserService {
         PlanType planType = userPlanRepository.findActivePlanTypeByUserId(userId)
                 .orElse(PlanType.FREE);
 
+        // 일일 크레딧: 매일 00:00에 100으로 리셋
         DailyCreditDto dailyCredit = DailyCreditDto.builder()
                 .balance(balance.getDailyFreeCredit())
                 .limit(balance.getDailyFreeLimit())
@@ -104,8 +105,9 @@ public class UserService {
                         : LocalDate.now().plusDays(1).atStartOfDay().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
                 .build();
 
-        // monthlyCredit = freeCredit + paidCredit
-        int monthlyBalance = balance.getFreeCredit() + balance.getPaidCredit();
+        // 월간 크레딧: 유료 플랜 구독 시 부여되는 크레딧
+        // FREE: 0, STANDARD: 2000, PRO: 5000
+        int monthlyBalance = balance.getPaidCredit();  // paidCredit만 월간 크레딧
         int monthlyLimit = planType.getMonthlyCreditLimit();
 
         MonthlyCreditDto monthlyCredit = MonthlyCreditDto.builder()

--- a/src/test/java/com/proovy/domain/user/service/SubscriptionServiceTest.java
+++ b/src/test/java/com/proovy/domain/user/service/SubscriptionServiceTest.java
@@ -1,5 +1,6 @@
 package com.proovy.domain.user.service;
 
+import com.proovy.domain.credit.service.CreditBalanceService;
 import com.proovy.domain.user.dto.request.UpgradePlanRequest;
 import com.proovy.domain.user.dto.response.SubscriptionResponse;
 import com.proovy.domain.user.entity.PlanType;
@@ -44,6 +45,9 @@ class SubscriptionServiceTest {
 
     @Mock
     private PlatformTransactionManager transactionManager;
+
+    @Mock
+    private CreditBalanceService creditBalanceService;
 
     private User testUser;
     private UserPlan freePlan;
@@ -217,6 +221,7 @@ class SubscriptionServiceTest {
             given(userRepository.findByIdForUpdate(userId)).willReturn(Optional.of(testUser));
             given(userPlanRepository.findActiveByUserIdForUpdate(userId)).willReturn(Optional.of(freePlan));
             given(userPlanRepository.save(any(UserPlan.class))).willAnswer(invocation -> invocation.getArgument(0));
+            willDoNothing().given(creditBalanceService).grantMonthlyCredit(userId, PlanType.STANDARD);
 
             // when
             SubscriptionResponse response = subscriptionService.upgradePlan(userId, new UpgradePlanRequest("standard"));
@@ -225,6 +230,7 @@ class SubscriptionServiceTest {
             assertThat(response.currentPlan().name()).isEqualTo("standard");
             assertThat(freePlan.getIsActive()).isFalse();
             then(userPlanRepository).should().save(any(UserPlan.class));
+            then(creditBalanceService).should().grantMonthlyCredit(userId, PlanType.STANDARD);
         }
 
         @Test
@@ -290,12 +296,14 @@ class SubscriptionServiceTest {
             given(userRepository.findByIdForUpdate(userId)).willReturn(Optional.of(testUser));
             given(userPlanRepository.findActiveByUserIdForUpdate(userId)).willReturn(Optional.of(freePlan));
             given(userPlanRepository.save(any(UserPlan.class))).willAnswer(invocation -> invocation.getArgument(0));
+            willDoNothing().given(creditBalanceService).grantMonthlyCredit(userId, PlanType.PRO);
 
             // when
             SubscriptionResponse response = subscriptionService.upgradePlan(userId, new UpgradePlanRequest(" pro "));
 
             // then
             assertThat(response.currentPlan().name()).isEqualTo("pro");
+            then(creditBalanceService).should().grantMonthlyCredit(userId, PlanType.PRO);
         }
 
         @Test


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #151 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

#### 1) CreditBalanceService.java
- `createSignupBalance()`에서 가입 보너스 제거
  - `freeCredit = 0` (가입 보너스 ❌)
  - FREE 플랜은 `paidCredit = 0`
  - `dailyFreeCredit/dailyFreeLimit`는 FREE daily limit(100)으로 설정
  - `dailyExpiresAt`는 다음날 00:00으로 설정

#### 2) UserService.java
- `getCreditInfo()` 월간 크레딧 산정 기준을 `paidCredit`로 단일화
  - `monthlyBalance = balance.getPaidCredit()`
  - `monthlyLimit = planType.getMonthlyCreditLimit()`

#### 3) AuthService.java
- 회원가입 완료 응답의 `welcomeCredit`를 정책에 맞게 0으로 변경
  - `welcomeCredit = 0`

### 정책 테이블(현재 기준)

<img width="444" height="148" alt="image" src="https://github.com/user-attachments/assets/addd5ca1-3c3c-4e4e-8be8-4a6fc62d93cc" />


## 📸 스크린샷



## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 코드 스타일 가이드를 준수했습니다
- [ ] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

  1) 가입 직후 welcomeCredit=0, freeCredit=0
  2) FREE 플랜 monthlyCredit.balance=0
  3) 유료 플랜 monthlyCredit.balance=paidCredit 일치
  4) totalAvailable = dailyFreeCredit + paidCredit (freeCredit 제외)