### PR TITLE
[Feat] 구독 취소 시 구독 재개 기능 구현

### DIFF
--- a/src/main/java/com/proovy/domain/user/controller/UserController.java
+++ b/src/main/java/com/proovy/domain/user/controller/UserController.java
@@ -193,7 +193,7 @@ public class UserController {
 
     @DeleteMapping("/me")
     @Operation(
-            operationId = "05_deleteUser",
+            operationId = "06_deleteUser",
             summary = "회원 탈퇴",
             description = "현재 로그인한 사용자의 계정을 영구 삭제합니다. 모든 노트, 파일, 구독 정보가 삭제됩니다.")
     @ApiResponses({

--- a/src/main/java/com/proovy/domain/user/controller/UserController.java
+++ b/src/main/java/com/proovy/domain/user/controller/UserController.java
@@ -153,6 +153,44 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @PatchMapping("/me/subscription/resume")
+    @Operation(
+            operationId = "05_resumeSubscription",
+            summary = "구독 자동 갱신 재개",
+            description = "구독 취소 예약 상태를 철회하고 구독의 자동 갱신을 재개합니다. 취소 예약이 되어 있던 구독이 만료일에 자동으로 갱신되도록 복원됩니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "구독 재개 성공",
+                    content = @Content(schema = @Schema(
+                            implementation = SubscriptionResponse.class,
+                            example = "{\"currentPlan\":{\"name\":\"pro\",\"displayName\":\"Pro\",\"price\":14900,\"currency\":\"KRW\",\"billingCycle\":\"MONTHLY\"},\"period\":{\"startDate\":\"2026-02-10\",\"endDate\":\"2026-03-10\",\"daysRemaining\":26},\"benefits\":{\"dailyCredit\":100,\"monthlyCredit\":3000,\"maxMonthlyCredit\":3000,\"storageLimit\":\"100GB\",\"maxFileSize\":\"100MB\",\"maxNotes\":-1},\"billing\":{\"nextBillingDate\":\"2026-03-10\",\"autoRenew\":true},\"availablePlans\":[],\"cancelInfo\":null}"
+                    ))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (USER4004: FREE 플랜 재개 시도, USER4007: 취소되지 않은 구독)",
+                    content = @Content(schema = @Schema(example = "{\"isSuccess\":false,\"code\":\"USER4007\",\"message\":\"취소 예약된 구독이 없습니다.\"}"))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(schema = @Schema(example = "{\"isSuccess\":false,\"code\":\"AUTH4013\",\"message\":\"유효하지 않은 토큰입니다.\"}"))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자 또는 활성 구독 없음 (USER4041: 사용자 없음, USER4042: 활성 구독 없음)",
+                    content = @Content(schema = @Schema(example = "{\"isSuccess\":false,\"code\":\"USER4042\",\"message\":\"활성화된 구독을 찾을 수 없습니다.\"}"))
+            )
+    })
+    public ResponseEntity<ApiResponse<SubscriptionResponse>> resumeSubscription(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        SubscriptionResponse response = subscriptionService.resumeSubscription(userPrincipal.getUserId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
     @DeleteMapping("/me")
     @Operation(
             operationId = "05_deleteUser",

--- a/src/main/java/com/proovy/domain/user/service/SubscriptionService.java
+++ b/src/main/java/com/proovy/domain/user/service/SubscriptionService.java
@@ -93,6 +93,28 @@ public class SubscriptionService {
         return schedulePlanChange(activePlan, PlanType.FREE);
     }
 
+    @Transactional
+    public SubscriptionResponse resumeSubscription(Long userId) {
+        userRepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER4041));
+
+        applyDuePlanChangeForUser(userId);
+
+        UserPlan activePlan = userPlanRepository.findActiveByUserIdForUpdate(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER4042));
+
+        if (activePlan.getPlanType() == PlanType.FREE) {
+            throw new BusinessException(ErrorCode.USER4004);
+        }
+
+        if (activePlan.getCanceledAt() == null) {
+            throw new BusinessException(ErrorCode.USER4007);
+        }
+
+        activePlan.resumeAutoRenew();
+        return SubscriptionResponse.from(activePlan);
+    }
+
     @Scheduled(fixedDelayString = "${proovy.subscription.plan-transition-fixed-delay-ms:60000}")
     @Transactional(readOnly = true)
     public void processDuePlanTransitions() {

--- a/src/main/java/com/proovy/global/response/ErrorCode.java
+++ b/src/main/java/com/proovy/global/response/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     USER4004("USER4004", "FREE 플랜은 취소할 수 없습니다.", HttpStatus.BAD_REQUEST),
     USER4005("USER4005", "이미 동일한 플랜 변경이 예약되어 있습니다.", HttpStatus.BAD_REQUEST),
     USER4006("USER4006", "활성화된 구독이 있습니다. 구독 취소 후 탈퇴해주세요.", HttpStatus.BAD_REQUEST),
+    USER4007("USER4007", "취소 예약된 구독이 없습니다.", HttpStatus.BAD_REQUEST),
     USER4041("USER4041", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     USER4042("USER4042", "활성화된 구독을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     USER4091("USER4091", "이미 존재하는 사용자입니다.", HttpStatus.CONFLICT),

--- a/src/test/java/com/proovy/domain/user/service/SubscriptionServiceTest.java
+++ b/src/test/java/com/proovy/domain/user/service/SubscriptionServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
@@ -419,6 +420,112 @@ class SubscriptionServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.USER4004);
+        }
+    }
+
+    @Nested
+    @DisplayName("resumeSubscription 메서드")
+    class ResumeSubscription {
+
+        @Test
+        @DisplayName("성공 - PRO 플랜 취소 후 재개")
+        void successResumeProPlan() {
+            // given
+            Long userId = 1L;
+            proPlan.schedulePlanChange(PlanType.FREE, LocalDateTime.now(ZoneId.of("Asia/Seoul")));
+            given(userRepository.findByIdForUpdate(userId)).willReturn(Optional.of(testUser));
+            given(userPlanRepository.findActiveByUserIdForUpdate(userId)).willReturn(Optional.of(proPlan));
+
+            // when
+            SubscriptionResponse response = subscriptionService.resumeSubscription(userId);
+
+            // then
+            assertThat(response.currentPlan().name()).isEqualTo("pro");
+            assertThat(response.cancelInfo()).isNull();
+            assertThat(response.billing()).isNotNull();
+            assertThat(response.billing().autoRenew()).isTrue();
+            assertThat(proPlan.getCanceledAt()).isNull();
+            assertThat(proPlan.getNextPlanType()).isNull();
+        }
+
+        @Test
+        @DisplayName("성공 - STANDARD 플랜 취소 후 재개")
+        void successResumeStandardPlan() {
+            // given
+            Long userId = 1L;
+            standardPlan.schedulePlanChange(PlanType.FREE, LocalDateTime.now(ZoneId.of("Asia/Seoul")));
+            given(userRepository.findByIdForUpdate(userId)).willReturn(Optional.of(testUser));
+            given(userPlanRepository.findActiveByUserIdForUpdate(userId)).willReturn(Optional.of(standardPlan));
+
+            // when
+            SubscriptionResponse response = subscriptionService.resumeSubscription(userId);
+
+            // then
+            assertThat(response.currentPlan().name()).isEqualTo("standard");
+            assertThat(response.cancelInfo()).isNull();
+            assertThat(response.billing()).isNotNull();
+            assertThat(response.billing().autoRenew()).isTrue();
+            assertThat(standardPlan.getCanceledAt()).isNull();
+            assertThat(standardPlan.getNextPlanType()).isNull();
+        }
+
+        @Test
+        @DisplayName("실패 - FREE 플랜은 재개 불가")
+        void failResumeFreePlan() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findByIdForUpdate(userId)).willReturn(Optional.of(testUser));
+            given(userPlanRepository.findActiveByUserIdForUpdate(userId)).willReturn(Optional.of(freePlan));
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.resumeSubscription(userId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER4004);
+        }
+
+        @Test
+        @DisplayName("실패 - 취소되지 않은 구독은 재개 불가")
+        void failResumeNotCanceledSubscription() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findByIdForUpdate(userId)).willReturn(Optional.of(testUser));
+            given(userPlanRepository.findActiveByUserIdForUpdate(userId)).willReturn(Optional.of(proPlan));
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.resumeSubscription(userId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER4007);
+        }
+
+        @Test
+        @DisplayName("실패 - 활성 구독이 없는 경우")
+        void failNoActiveSubscription() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findByIdForUpdate(userId)).willReturn(Optional.of(testUser));
+            given(userPlanRepository.findActiveByUserIdForUpdate(userId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.resumeSubscription(userId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER4042);
+        }
+
+        @Test
+        @DisplayName("실패 - 사용자 없음")
+        void failUserNotFound() {
+            // given
+            Long userId = 999L;
+            given(userRepository.findByIdForUpdate(userId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.resumeSubscription(userId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER4041);
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #153 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 구독 취소 시 구독 재개 기능을 구현
- 관련 에러코드 추가 

## 📸 스크린샷

<img width="1272" height="956" alt="image" src="https://github.com/user-attachments/assets/de939e6c-b512-4923-910f-b163080ac728" />

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 취소된 구독을 재개할 수 있는 API와 기능이 추가되었습니다. 자동 갱신 설정이 재복구됩니다.

* **개선사항**
  * 재개 시 발생 가능한 여러 오류 케이스에 대한 검증 및 신규 오류 응답(취소 예약된 구독 없음)이 추가되었습니다.
  * 공개 API의 일부 식별자(삭제 유저 관련)가 업데이트되었습니다.

* **테스트**
  * 구독 재개 관련 포괄적인 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->