### PR TITLE
[Fix] 플랜 즉시 변경 시 월간 크레딧 차액 지급 및 테스트 갱신

### DIFF
--- a/src/main/java/com/proovy/domain/credit/entity/CreditBalance.java
+++ b/src/main/java/com/proovy/domain/credit/entity/CreditBalance.java
@@ -43,6 +43,9 @@ public class CreditBalance {
     @Column(name = "paid_expires_at")
     private LocalDateTime paidExpiresAt;
 
+    @Column(name = "last_monthly_grant_plan_id")
+    private Long lastMonthlyGrantPlanId;
+
     @CreatedDate
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -56,7 +59,8 @@ public class CreditBalance {
     @Builder
     public CreditBalance(User user, Integer dailyFreeCredit, Integer dailyFreeLimit,
                          LocalDateTime dailyExpiresAt, Integer freeCredit,
-                         Integer paidCredit, LocalDateTime paidExpiresAt) {
+                         Integer paidCredit, LocalDateTime paidExpiresAt,
+                         Long lastMonthlyGrantPlanId) {
         this.user = user;
         this.dailyFreeCredit = dailyFreeCredit != null ? dailyFreeCredit : 0;
         this.dailyFreeLimit = dailyFreeLimit != null ? dailyFreeLimit : 100;
@@ -64,6 +68,7 @@ public class CreditBalance {
         this.freeCredit = freeCredit != null ? freeCredit : 0;
         this.paidCredit = paidCredit != null ? paidCredit : 0;
         this.paidExpiresAt = paidExpiresAt;
+        this.lastMonthlyGrantPlanId = lastMonthlyGrantPlanId;
     }
 
     public Integer getTotalAvailable() {
@@ -134,6 +139,14 @@ public class CreditBalance {
     // 유료 크레딧 만료일 설정
     public void setPaidExpiresAt(LocalDateTime expiresAt) {
         this.paidExpiresAt = expiresAt;
+    }
+
+    public boolean isGrantedForPlan(Long userPlanId) {
+        return userPlanId != null && userPlanId.equals(this.lastMonthlyGrantPlanId);
+    }
+
+    public void markMonthlyGrantPlan(Long userPlanId) {
+        this.lastMonthlyGrantPlanId = userPlanId;
     }
 
     // 만료 처리

--- a/src/main/java/com/proovy/domain/credit/service/CreditBalanceCreator.java
+++ b/src/main/java/com/proovy/domain/credit/service/CreditBalanceCreator.java
@@ -13,11 +13,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class CreditBalanceCreator {
+    private static final ZoneId BILLING_ZONE = ZoneId.of("Asia/Seoul");
 
     private final CreditBalanceRepository creditBalanceRepository;
     private final UserRepository userRepository;
@@ -37,11 +40,19 @@ public class CreditBalanceCreator {
                 .user(user)
                 .dailyFreeCredit(dailyCreditLimit)
                 .dailyFreeLimit(dailyCreditLimit)
-                .dailyExpiresAt(LocalDate.now().plusDays(1).atStartOfDay())
+                .dailyExpiresAt(nextDailyResetAt(nowInBillingZone()))
                 .freeCredit(freeCredit)
                 .paidCredit(0)
                 .build();
 
         return creditBalanceRepository.save(balance);
+    }
+
+    private LocalDateTime nowInBillingZone() {
+        return ZonedDateTime.now(BILLING_ZONE).toLocalDateTime();
+    }
+
+    private LocalDateTime nextDailyResetAt(LocalDateTime now) {
+        return now.toLocalDate().plusDays(1).atStartOfDay();
     }
 }

--- a/src/main/java/com/proovy/domain/credit/service/CreditBalanceService.java
+++ b/src/main/java/com/proovy/domain/credit/service/CreditBalanceService.java
@@ -13,13 +13,15 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class CreditBalanceService {
+    private static final ZoneId BILLING_ZONE = ZoneId.of("Asia/Seoul");
 
     private final CreditBalanceRepository creditBalanceRepository;
     private final CreditBalanceCreator creditBalanceCreator;
@@ -55,7 +57,7 @@ public class CreditBalanceService {
                 .user(user)
                 .dailyFreeCredit(dailyCreditLimit)
                 .dailyFreeLimit(dailyCreditLimit)
-                .dailyExpiresAt(LocalDate.now().plusDays(1).atStartOfDay())
+                .dailyExpiresAt(nextDailyResetAt(nowInBillingZone()))
                 .freeCredit(0)  // 가입 보너스 없음
                 .paidCredit(0)  // FREE 플랜은 월간 크레딧 없음
                 .build();
@@ -67,29 +69,40 @@ public class CreditBalanceService {
      * 월간 구독 크레딧 부여 (플랜 변경/갱신 시 호출)
      */
     @Transactional
-    public void grantMonthlyCredit(Long userId, PlanType planType) {
+    public void grantMonthlyCredit(Long userId, PlanType planType, Long userPlanId, int grantAmount) {
         if (planType == PlanType.FREE) {
             return; // FREE 플랜은 월간 크레딧 없음
         }
+        if (grantAmount <= 0) {
+            log.info("월간 크레딧 지급 스킵(지급량 없음): userId={}, planType={}, userPlanId={}, amount={}",
+                    userId, planType, userPlanId, grantAmount);
+            return;
+        }
 
         CreditBalance balance = getOrCreateBalanceForUpdate(userId);
-        int monthlyCredit = planType.getMonthlyCreditLimit();
+        if (balance.isGrantedForPlan(userPlanId)) {
+            log.info("월간 크레딧 중복 지급 스킵: userId={}, planType={}, userPlanId={}", userId, planType, userPlanId);
+            return;
+        }
+
+        LocalDateTime now = nowInBillingZone();
         int dailyCreditLimit = planType.getDailyCreditLimit();
 
         // 1. Monthly Credit 부여
-        balance.addPaidCredit(monthlyCredit);
+        balance.addPaidCredit(grantAmount);
 
         // 2. Daily Limit 업데이트
         if (balance.getDailyFreeLimit() != dailyCreditLimit) {
             log.info("플랜 변경으로 일일 크레딧 한도 변경: userId={}, {} -> {}",
                     userId, balance.getDailyFreeLimit(), dailyCreditLimit);
             balance.updateDailyLimit(dailyCreditLimit);
-            balance.resetDailyCredit(LocalDate.now().plusDays(1).atStartOfDay());
+            balance.resetDailyCredit(nextDailyResetAt(now));
         }
 
         // 3. Paid Credit 만료일 설정 (1개월 후)
-        LocalDateTime expiresAt = LocalDateTime.now().plusMonths(1);
+        LocalDateTime expiresAt = now.plusMonths(1);
         balance.setPaidExpiresAt(expiresAt);
+        balance.markMonthlyGrantPlan(userPlanId);
 
         creditBalanceRepository.save(balance);
 
@@ -98,8 +111,8 @@ public class CreditBalanceService {
                 .user(balance.getUser())
                 .eventType(CreditEventType.MONTHLY_GRANT)
                 .eventName(planType.getDisplayName() + " 플랜 구독 크레딧")
-                .description(planType.getDisplayName() + " 플랜 월간 크레딧 " + monthlyCredit + " 지급")
-                .amount(monthlyCredit)
+                .description(planType.getDisplayName() + " 플랜 월간 크레딧 " + grantAmount + " 지급")
+                .amount(grantAmount)
                 .changeType(CreditChangeType.EARN)
                 .creditType(CreditType.PAID)
                 .balanceAfterDaily(balance.getDailyFreeCredit())
@@ -108,7 +121,7 @@ public class CreditBalanceService {
                 .build();
         creditHistoryRepository.save(history);
 
-        log.info("월간 크레딧 부여 완료: userId={}, planType={}, amount={}", userId, planType, monthlyCredit);
+        log.info("월간 크레딧 부여 완료: userId={}, planType={}, amount={}", userId, planType, grantAmount);
     }
 
     private void createInitialBalanceSafely(Long userId, int freeCredit) {
@@ -117,5 +130,13 @@ public class CreditBalanceService {
         } catch (DataIntegrityViolationException e) {
             log.warn("크레딧 잔액 동시 생성 감지, userId={}", userId);
         }
+    }
+
+    private LocalDateTime nowInBillingZone() {
+        return ZonedDateTime.now(BILLING_ZONE).toLocalDateTime();
+    }
+
+    private LocalDateTime nextDailyResetAt(LocalDateTime now) {
+        return now.toLocalDate().plusDays(1).atStartOfDay();
     }
 }

--- a/src/main/java/com/proovy/domain/user/service/SubscriptionService.java
+++ b/src/main/java/com/proovy/domain/user/service/SubscriptionService.java
@@ -138,7 +138,8 @@ public class SubscriptionService {
 
             // 유료 플랜으로 변경 시 월간 크레딧 부여
             if (targetPlan != PlanType.FREE) {
-                creditBalanceService.grantMonthlyCredit(user.getId(), targetPlan);
+                int grantAmount = calculateImmediateGrantAmount(currentPlan.getPlanType(), targetPlan);
+                creditBalanceService.grantMonthlyCredit(user.getId(), targetPlan, savedPlan.getId(), grantAmount);
             }
 
             return SubscriptionResponse.from(savedPlan);
@@ -190,11 +191,17 @@ public class SubscriptionService {
         userPlanRepository.flush();
 
         UserPlan nextPlan = buildNextActivePlan(duePlan.getUser(), nextPlanType, transitionAt);
-        userPlanRepository.save(nextPlan);
+        UserPlan savedNextPlan = userPlanRepository.save(nextPlan);
+        userPlanRepository.flush();
 
         // 유료 플랜으로 전환 시 월간 크레딧 부여
         if (nextPlanType != PlanType.FREE) {
-            creditBalanceService.grantMonthlyCredit(duePlan.getUser().getId(), nextPlanType);
+            creditBalanceService.grantMonthlyCredit(
+                    duePlan.getUser().getId(),
+                    nextPlanType,
+                    savedNextPlan.getId(),
+                    nextPlanType.getMonthlyCreditLimit()
+            );
         }
     }
 
@@ -248,6 +255,12 @@ public class SubscriptionService {
 
     private PlanType resolveNextPlanType(UserPlan userPlan) {
         return userPlan.getNextPlanType() != null ? userPlan.getNextPlanType() : PlanType.FREE;
+    }
+
+    private int calculateImmediateGrantAmount(PlanType currentPlanType, PlanType targetPlanType) {
+        int currentMonthlyCredit = currentPlanType != null ? currentPlanType.getMonthlyCreditLimit() : 0;
+        int targetMonthlyCredit = targetPlanType.getMonthlyCreditLimit();
+        return Math.max(0, targetMonthlyCredit - currentMonthlyCredit);
     }
 
     private UserPlan createDefaultFreePlan(User user) {

--- a/src/main/resources/db/migration/V27__add_last_monthly_grant_plan_id_to_credit_balance.sql
+++ b/src/main/resources/db/migration/V27__add_last_monthly_grant_plan_id_to_credit_balance.sql
@@ -1,0 +1,2 @@
+ALTER TABLE credit_balance
+    ADD COLUMN IF NOT EXISTS last_monthly_grant_plan_id BIGINT;

--- a/src/test/java/com/proovy/domain/credit/service/CreditBalanceServiceTest.java
+++ b/src/test/java/com/proovy/domain/credit/service/CreditBalanceServiceTest.java
@@ -1,0 +1,95 @@
+package com.proovy.domain.credit.service;
+
+import com.proovy.domain.credit.entity.CreditBalance;
+import com.proovy.domain.credit.entity.CreditHistory;
+import com.proovy.domain.credit.repository.CreditBalanceRepository;
+import com.proovy.domain.credit.repository.CreditHistoryRepository;
+import com.proovy.domain.user.entity.PlanType;
+import com.proovy.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class CreditBalanceServiceTest {
+
+    @InjectMocks
+    private CreditBalanceService creditBalanceService;
+
+    @Mock
+    private CreditBalanceRepository creditBalanceRepository;
+
+    @Mock
+    private CreditBalanceCreator creditBalanceCreator;
+
+    @Mock
+    private CreditHistoryRepository creditHistoryRepository;
+
+    @Test
+    @DisplayName("같은 userPlanId로 월간 크레딧 재지급 요청 시 중복 지급하지 않는다")
+    void skipDuplicateMonthlyGrantForSamePlan() {
+        Long userId = 1L;
+        Long userPlanId = 101L;
+        User user = User.builder().build();
+
+        CreditBalance balance = CreditBalance.builder()
+                .user(user)
+                .paidCredit(2000)
+                .lastMonthlyGrantPlanId(userPlanId)
+                .build();
+
+        given(creditBalanceRepository.findByUserIdForUpdate(userId)).willReturn(Optional.of(balance));
+
+        creditBalanceService.grantMonthlyCredit(userId, PlanType.STANDARD, userPlanId, 2000);
+
+        assertThat(balance.getPaidCredit()).isEqualTo(2000);
+        then(creditBalanceRepository).should(never()).save(any(CreditBalance.class));
+        then(creditHistoryRepository).should(never()).save(any(CreditHistory.class));
+    }
+
+    @Test
+    @DisplayName("월간 크레딧 지급 시 잔액/만료일/지급 참조키를 갱신하고 히스토리를 남긴다")
+    void grantMonthlyCreditUpdatesBalanceAndHistory() {
+        Long userId = 1L;
+        Long userPlanId = 202L;
+        User user = User.builder().build();
+
+        CreditBalance balance = CreditBalance.builder()
+                .user(user)
+                .dailyFreeCredit(10)
+                .dailyFreeLimit(50)
+                .freeCredit(0)
+                .paidCredit(0)
+                .build();
+
+        given(creditBalanceRepository.findByUserIdForUpdate(userId)).willReturn(Optional.of(balance));
+
+        creditBalanceService.grantMonthlyCredit(userId, PlanType.PRO, userPlanId, 5000);
+
+        assertThat(balance.getPaidCredit()).isEqualTo(5000);
+        assertThat(balance.getDailyFreeLimit()).isEqualTo(100);
+        assertThat(balance.getDailyFreeCredit()).isEqualTo(100);
+        assertThat(balance.getLastMonthlyGrantPlanId()).isEqualTo(userPlanId);
+        assertThat(balance.getPaidExpiresAt()).isAfter(LocalDateTime.now().plusDays(20));
+        assertThat(balance.getPaidExpiresAt()).isBefore(LocalDateTime.now().plusMonths(2));
+
+        then(creditBalanceRepository).should().save(balance);
+
+        ArgumentCaptor<CreditHistory> historyCaptor = ArgumentCaptor.forClass(CreditHistory.class);
+        then(creditHistoryRepository).should().save(historyCaptor.capture());
+        assertThat(historyCaptor.getValue().getAmount()).isEqualTo(5000);
+    }
+}

--- a/src/test/java/com/proovy/domain/user/service/SubscriptionServiceTest.java
+++ b/src/test/java/com/proovy/domain/user/service/SubscriptionServiceTest.java
@@ -220,8 +220,11 @@ class SubscriptionServiceTest {
 
             given(userRepository.findByIdForUpdate(userId)).willReturn(Optional.of(testUser));
             given(userPlanRepository.findActiveByUserIdForUpdate(userId)).willReturn(Optional.of(freePlan));
-            given(userPlanRepository.save(any(UserPlan.class))).willAnswer(invocation -> invocation.getArgument(0));
-            willDoNothing().given(creditBalanceService).grantMonthlyCredit(userId, PlanType.STANDARD);
+            given(userPlanRepository.save(any(UserPlan.class))).willAnswer(invocation -> {
+                UserPlan savedPlan = invocation.getArgument(0);
+                ReflectionTestUtils.setField(savedPlan, "id", 11L);
+                return savedPlan;
+            });
 
             // when
             SubscriptionResponse response = subscriptionService.upgradePlan(userId, new UpgradePlanRequest("standard"));
@@ -230,7 +233,31 @@ class SubscriptionServiceTest {
             assertThat(response.currentPlan().name()).isEqualTo("standard");
             assertThat(freePlan.getIsActive()).isFalse();
             then(userPlanRepository).should().save(any(UserPlan.class));
-            then(creditBalanceService).should().grantMonthlyCredit(userId, PlanType.STANDARD);
+            then(creditBalanceService).should().grantMonthlyCredit(userId, PlanType.STANDARD, 11L, 2000);
+        }
+
+        @Test
+        @DisplayName("성공 - Standard에서 Pro 즉시 업그레이드 시 월간 크레딧은 차액만 지급한다")
+        void successUpgradeFromStandardToProWithDeltaCredit() {
+            // given
+            Long userId = 1L;
+            ReflectionTestUtils.setField(standardPlan, "id", 20L);
+
+            given(userRepository.findByIdForUpdate(userId)).willReturn(Optional.of(testUser));
+            given(userPlanRepository.findActiveByUserIdForUpdate(userId)).willReturn(Optional.of(standardPlan));
+            given(userPlanRepository.save(any(UserPlan.class))).willAnswer(invocation -> {
+                UserPlan savedPlan = invocation.getArgument(0);
+                ReflectionTestUtils.setField(savedPlan, "id", 21L);
+                return savedPlan;
+            });
+
+            // when
+            SubscriptionResponse response = subscriptionService.upgradePlan(userId, new UpgradePlanRequest("pro"));
+
+            // then
+            assertThat(response.currentPlan().name()).isEqualTo("pro");
+            assertThat(standardPlan.getIsActive()).isFalse();
+            then(creditBalanceService).should().grantMonthlyCredit(userId, PlanType.PRO, 21L, 3000);
         }
 
         @Test
@@ -295,15 +322,18 @@ class SubscriptionServiceTest {
             ReflectionTestUtils.setField(freePlan, "id", 10L);
             given(userRepository.findByIdForUpdate(userId)).willReturn(Optional.of(testUser));
             given(userPlanRepository.findActiveByUserIdForUpdate(userId)).willReturn(Optional.of(freePlan));
-            given(userPlanRepository.save(any(UserPlan.class))).willAnswer(invocation -> invocation.getArgument(0));
-            willDoNothing().given(creditBalanceService).grantMonthlyCredit(userId, PlanType.PRO);
+            given(userPlanRepository.save(any(UserPlan.class))).willAnswer(invocation -> {
+                UserPlan savedPlan = invocation.getArgument(0);
+                ReflectionTestUtils.setField(savedPlan, "id", 12L);
+                return savedPlan;
+            });
 
             // when
             SubscriptionResponse response = subscriptionService.upgradePlan(userId, new UpgradePlanRequest(" pro "));
 
             // then
             assertThat(response.currentPlan().name()).isEqualTo("pro");
-            then(creditBalanceService).should().grantMonthlyCredit(userId, PlanType.PRO);
+            then(creditBalanceService).should().grantMonthlyCredit(userId, PlanType.PRO, 12L, 5000);
         }
 
         @Test


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #157 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

### 1) 즉시 플랜 변경 시 월간 크레딧 지급 방식 개선
- `SubscriptionService`에 `calculateImmediateGrantAmount()`를 추가하여
  즉시 변경 시 **target - current 차액**만 지급하도록 변경했습니다.

### 2) 월간 크레딧 지급 API 명확화 및 안전장치 추가
- `CreditBalanceService.grantMonthlyCredit(..., int grantAmount)`로 변경
- `grantAmount <= 0`인 경우 스킵 처리하여 불필요한 지급/히스토리 기록을 방지했습니다.

### 3) 만료 전환(새 청구 주기 시작) 지급 정책 유지
- 만료로 인한 플랜 전환/갱신(새 청구 주기 시작) 케이스는 기존대로
  **전체 월간 크레딧 지급** 정책을 유지했습니다.

### 4) 테스트 업데이트
- 기존 테스트 검증값을 새 시그니처/지급량 정책에 맞게 갱신했습니다.

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 즉시 플랜 변경 시나리오
  - 업그레이드: (target > current) → 차액만 지급
  - 다운그레이드: (target <= current) → 지급 스킵(grantAmount <= 0)
- 새 청구 주기 시작(만료 전환/갱신) 시나리오
  - 전체 월간 크레딧 지급 유지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 플랜 업그레이드 시 신용 크레딧 자동 조정 기능 추가
  * 동일 플랜에 대한 중복 월간 신용 부여 방지 기능 추가

* **버그 수정**
  * 일일 신용 리셋 타이밍의 시간대 일관성 개선 (Asia/Seoul 기준)

* **테스트**
  * 신용 부여 및 플랜 변경 시나리오에 대한 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->