### PR TITLE
[Fix] /conversations api를 호출할 때 accesstoken을 전달하도록 보완

### DIFF
--- a/src/main/java/com/proovy/domain/conversation/controller/ConversationController.java
+++ b/src/main/java/com/proovy/domain/conversation/controller/ConversationController.java
@@ -85,9 +85,15 @@ public class ConversationController {
             @Parameter(hidden = true)
             @AuthenticationPrincipal UserPrincipal userPrincipal,
 
+            @Parameter(hidden = true)
+            @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+
             @Valid @RequestBody ConversationRequest request
     ) {
         Long resolvedUserId = userPrincipal.getUserId();
+
+        // Authorization 헤더에서 Bearer 토큰 추출
+        String accessToken = extractBearerToken(authorizationHeader);
 
         if (Boolean.FALSE.equals(isStream)) {
             throw new UnsupportedOperationException("invoke 모드는 아직 구현되지 않았습니다. isStream=true 로만 호출해 주세요.");
@@ -95,14 +101,24 @@ public class ConversationController {
 
         log.info("Create conversation - userId: {}, isStream: {}", resolvedUserId, isStream);
 
-        return streamResponse(resolvedUserId, request);
+        return streamResponse(resolvedUserId, request, accessToken);
+    }
+
+    /**
+     * Authorization 헤더에서 Bearer 토큰 추출
+     */
+    private String extractBearerToken(String authorizationHeader) {
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            return authorizationHeader.substring(7);
+        }
+        return null;
     }
 
     /**
      * SSE 스트리밍 응답 생성
      */
-    private Flux<ServerSentEvent<String>> streamResponse(Long userId, ConversationRequest request) {
-        return chatService.streamConversation(userId, request)
+    private Flux<ServerSentEvent<String>> streamResponse(Long userId, ConversationRequest request, String accessToken) {
+        return chatService.streamConversation(userId, request, accessToken)
                 .map(event -> {
                     try {
                         // ProovyAiStreamEvent를 JSON 문자열로 변환

--- a/src/main/java/com/proovy/domain/conversation/dto/request/ProovyAiRequest.java
+++ b/src/main/java/com/proovy/domain/conversation/dto/request/ProovyAiRequest.java
@@ -43,4 +43,8 @@ public class ProovyAiRequest {
     // 선택: agentConfig - 기존 metadata를 이 필드로 보낸다.
     @JsonProperty("agentConfig")
     private Map<String, Object> agentConfig;
+
+    // 선택: authToken - Spring 백엔드 인증 토큰 (크레딧 API 호출용)
+    @JsonProperty("authToken")
+    private String authToken;
 }

--- a/src/main/java/com/proovy/domain/conversation/service/ChatService.java
+++ b/src/main/java/com/proovy/domain/conversation/service/ChatService.java
@@ -14,15 +14,17 @@ public interface ChatService {
      * 스트리밍 대화 요청 (SSE)
      * @param userId 사용자 ID
      * @param request 대화 요청
+     * @param accessToken 사용자 인증 토큰 (AI 서버에서 Spring API 호출 시 사용)
      * @return SSE 스트림
      */
-    Flux<ProovyAiStreamEvent> streamConversation(Long userId, ConversationRequest request);
+    Flux<ProovyAiStreamEvent> streamConversation(Long userId, ConversationRequest request, String accessToken);
 
     /**
      * 단건 대화 요청 (향후 구현)
      * @param userId 사용자 ID
      * @param request 대화 요청
+     * @param accessToken 사용자 인증 토큰 (AI 서버에서 Spring API 호출 시 사용)
      * @return 대화 응답
      */
-    ConversationResponse invokeConversation(Long userId, ConversationRequest request);
+    ConversationResponse invokeConversation(Long userId, ConversationRequest request, String accessToken);
 }

--- a/src/main/java/com/proovy/domain/conversation/service/ChatServiceImpl.java
+++ b/src/main/java/com/proovy/domain/conversation/service/ChatServiceImpl.java
@@ -67,7 +67,7 @@ public class ChatServiceImpl implements ChatService {
 
     @Override
     @Transactional
-    public Flux<ProovyAiStreamEvent> streamConversation(Long userId, ConversationRequest request) {
+    public Flux<ProovyAiStreamEvent> streamConversation(Long userId, ConversationRequest request, String accessToken) {
         log.info("[Chat] streamConversation 시작 - userId: {}, textLength: {}, features: {}, assetIds: {}",
             userId,
             request.getText() != null ? request.getText().length() : 0,
@@ -164,6 +164,7 @@ public class ChatServiceImpl implements ChatService {
             .chosenFeatures(request.getChosenFeatures())
             .streamTokens(true)
             .agentConfig(buildMetadata(request))
+            .authToken(accessToken)  // Spring 인증 토큰 전달
             .build();
 
         log.info("[Chat] Proovy-ai 요청 생성 - threadId: {}, filesUrl: {}, message: {}",
@@ -270,7 +271,7 @@ public class ChatServiceImpl implements ChatService {
 
     @Override
     @Transactional
-    public ConversationResponse invokeConversation(Long userId, ConversationRequest request) {
+    public ConversationResponse invokeConversation(Long userId, ConversationRequest request, String accessToken) {
         // TODO: 향후 isStream=false 시 구현
         throw new UnsupportedOperationException("invoke 모드는 아직 구현되지 않았습니다.");
     }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #155 

## 🏷️ PR 타입

- [x] 🐛 버그 수정 (Bug Fix)

## 📝 작업 내용

- ProovyAiRequest에 authToken 필드 추가
- ChatService의 ai api 호출 함수에 대해 accessToken 파라미터 추가
- ChatServiceImpl에서 accessToken을 받아서 authToken 전달


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 배포 후 테스트할 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 대화 기능에 향상된 토큰 기반 인증이 추가되었습니다.
  * 실시간 스트리밍 대화에서 인증 토큰이 안전하게 처리됩니다.

* **Improvements**
  * 대화 API 호출 시 인증 처리의 안정성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->