### PR TITLE
[Fix] MessageRepository의 native query에서 컬럼명 수정

### DIFF
--- a/src/main/java/com/proovy/domain/conversation/repository/ConversationRepository.java
+++ b/src/main/java/com/proovy/domain/conversation/repository/ConversationRepository.java
@@ -21,12 +21,12 @@ public interface ConversationRepository extends JpaRepository<Conversation, Long
     /**
      * 특정 노트의 대화 조회
      */
-    Optional<Conversation> findByNoteId(Long noteId);
+    Optional<Conversation> findByNote_Id(Long noteId);
 
     /**
      * 특정 노트의 대화 개수 조회
      */
-    long countByNoteId(Long noteId);
+    long countByNote_Id(Long noteId);
 
     /**
      * 특정 노트의 모든 대화 조회
@@ -54,7 +54,7 @@ public interface ConversationRepository extends JpaRepository<Conversation, Long
     /**
      * 특정 노트의 대화 조회 (페이징)
      */
-    Page<Conversation> findByNoteIdOrderByCreatedAtDesc(Long noteId, Pageable pageable);
+    Page<Conversation> findByNote_IdOrderByCreatedAtDesc(Long noteId, Pageable pageable);
 
     /**
      * 여러 노트의 대화 개수를 한 번에 조회 (배치 쿼리)

--- a/src/main/java/com/proovy/domain/conversation/repository/MessageRepository.java
+++ b/src/main/java/com/proovy/domain/conversation/repository/MessageRepository.java
@@ -26,16 +26,16 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
      */
     @Query(value = """
             SELECT m.* FROM messages m
-            JOIN conversations c ON m.conversation_id = c.id
-            JOIN notes n ON c.note_id = n.id
+            JOIN conversations c ON m.conversation_id = c.conversation_id
+            JOIN notes n ON c.note_id = n.note_id
             WHERE n.user_id = :userId
               AND m.search_vector @@ plainto_tsquery('simple', :query)
             ORDER BY ts_rank(m.search_vector, plainto_tsquery('simple', :query)) DESC
             """,
             countQuery = """
             SELECT COUNT(*) FROM messages m
-            JOIN conversations c ON m.conversation_id = c.id
-            JOIN notes n ON c.note_id = n.id
+            JOIN conversations c ON m.conversation_id = c.conversation_id
+            JOIN notes n ON c.note_id = n.note_id
             WHERE n.user_id = :userId
               AND m.search_vector @@ plainto_tsquery('simple', :query)
             """,
@@ -50,19 +50,19 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
      */
     @Query(value = """
             SELECT m.* FROM messages m
-            JOIN conversations c ON m.conversation_id = c.id
-            JOIN notes n ON c.note_id = n.id
+            JOIN conversations c ON m.conversation_id = c.conversation_id
+            JOIN notes n ON c.note_id = n.note_id
             WHERE n.user_id = :userId
-              AND n.id = :noteId
+              AND n.note_id = :noteId
               AND m.search_vector @@ plainto_tsquery('simple', :query)
             ORDER BY ts_rank(m.search_vector, plainto_tsquery('simple', :query)) DESC
             """,
             countQuery = """
             SELECT COUNT(*) FROM messages m
-            JOIN conversations c ON m.conversation_id = c.id
-            JOIN notes n ON c.note_id = n.id
+            JOIN conversations c ON m.conversation_id = c.conversation_id
+            JOIN notes n ON c.note_id = n.note_id
             WHERE n.user_id = :userId
-              AND n.id = :noteId
+              AND n.note_id = :noteId
               AND m.search_vector @@ plainto_tsquery('simple', :query)
             """,
             nativeQuery = true)
@@ -77,16 +77,16 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
      */
     @Query(value = """
             SELECT m.* FROM messages m
-            JOIN conversations c ON m.conversation_id = c.id
-            JOIN notes n ON c.note_id = n.id
+            JOIN conversations c ON m.conversation_id = c.conversation_id
+            JOIN notes n ON c.note_id = n.note_id
             WHERE n.user_id = :userId
               AND m.content ILIKE '%' || :query || '%'
             ORDER BY similarity(m.content, :query) DESC, m.created_at DESC
             """,
             countQuery = """
             SELECT COUNT(*) FROM messages m
-            JOIN conversations c ON m.conversation_id = c.id
-            JOIN notes n ON c.note_id = n.id
+            JOIN conversations c ON m.conversation_id = c.conversation_id
+            JOIN notes n ON c.note_id = n.note_id
             WHERE n.user_id = :userId
               AND m.content ILIKE '%' || :query || '%'
             """,
@@ -101,19 +101,19 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
      */
     @Query(value = """
             SELECT m.* FROM messages m
-            JOIN conversations c ON m.conversation_id = c.id
-            JOIN notes n ON c.note_id = n.id
+            JOIN conversations c ON m.conversation_id = c.conversation_id
+            JOIN notes n ON c.note_id = n.note_id
             WHERE n.user_id = :userId
-              AND n.id = :noteId
+              AND n.note_id = :noteId
               AND m.content ILIKE '%' || :query || '%'
             ORDER BY similarity(m.content, :query) DESC, m.created_at DESC
             """,
             countQuery = """
             SELECT COUNT(*) FROM messages m
-            JOIN conversations c ON m.conversation_id = c.id
-            JOIN notes n ON c.note_id = n.id
+            JOIN conversations c ON m.conversation_id = c.conversation_id
+            JOIN notes n ON c.note_id = n.note_id
             WHERE n.user_id = :userId
-              AND n.id = :noteId
+              AND n.note_id = :noteId
               AND m.content ILIKE '%' || :query || '%'
             """,
             nativeQuery = true)

--- a/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
+++ b/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
@@ -304,7 +304,7 @@ public class NoteServiceImpl implements NoteService {
         }
 
         // 2. 통계용 정보 수집 (엔티티 조회가 아닌 count/sum 쿼리 사용)
-        long conversationCount = conversationRepository.countByNoteId(noteId);
+        long conversationCount = conversationRepository.countByNote_Id(noteId);
 
         // 3. S3 삭제를 위한 Asset 정보만 조회 (영속성 컨텍스트 오염 방지를 위해 별도 처리)
         List<Asset> assets = assetRepository.findAllByNoteId(noteId);
@@ -410,11 +410,11 @@ public class NoteServiceImpl implements NoteService {
         int conversationLimit = 50; // 기본 대화 제한 수
 
         // 4. 전체 대화 수 조회
-        long totalConversations = conversationRepository.countByNoteId(noteId);
+        long totalConversations = conversationRepository.countByNote_Id(noteId);
 
         // 5. 대화 페이징 조회
         Pageable pageable = PageRequest.of(conversationPage, conversationSize, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<Conversation> conversationPage1 = conversationRepository.findByNoteIdOrderByCreatedAtDesc(noteId, pageable);
+        Page<Conversation> conversationPage1 = conversationRepository.findByNote_IdOrderByCreatedAtDesc(noteId, pageable);
 
         // 6. 대화 ID 목록 추출
         List<Long> conversationIds = conversationPage1.getContent().stream()


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #160 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

### 1) `MessageRepository.java` 수정
- **컬럼명 수정**:
  - `searchByFullText`: `c.id → c.conversation_id`, `n.id → n.note_id`
  - `searchByFullTextAndNoteId`: `c.id → c.conversation_id`, `n.id → n.note_id`, `n.note_id = :noteId`
  - `searchByTrigram`: `c.id → c.conversation_id`, `n.id → n.note_id`
  - `searchByTrigramAndNoteId`: `c.id → c.conversation_id`, `n.id → n.note_id`, `n.note_id = :noteId`


### 3) 기존 쿼리에서 컬럼명이 실제 데이터베이스와 일치하게 변경됨으로써, 쿼리 정확성 확보

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 대화 및 메시지 검색 기능의 데이터베이스 조회 안정성을 개선했습니다.
  * 노트별 대화 정보 조회 및 처리 과정에서 발생할 수 있는 오류를 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->