### PR TITLE
[Feat] 자동 갱신 및 일일 크레딧 초기화 스케줄러 추가

### DIFF
--- a/src/main/java/com/proovy/domain/credit/repository/CreditBalanceRepository.java
+++ b/src/main/java/com/proovy/domain/credit/repository/CreditBalanceRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface CreditBalanceRepository extends JpaRepository<CreditBalance, Long> {
@@ -22,4 +24,16 @@ public interface CreditBalanceRepository extends JpaRepository<CreditBalance, Lo
     @Modifying
     @Query("DELETE FROM CreditBalance cb WHERE cb.user.id = :userId")
     void deleteAllByUserId(@Param("userId") Long userId);
+
+    /**
+     * 일일 크레딧이 만료된 사용자 ID 목록 조회 (배치 처리용)
+     */
+    @Query(value = "SELECT id FROM credit_balance " +
+            "WHERE daily_expires_at IS NOT NULL " +
+            "AND daily_expires_at <= :now " +
+            "ORDER BY id " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<Long> findExpiredDailyCreditIds(@Param("now") LocalDateTime now,
+                                          @Param("limit") int limit);
 }

--- a/src/main/java/com/proovy/domain/credit/service/CreditBalanceService.java
+++ b/src/main/java/com/proovy/domain/credit/service/CreditBalanceService.java
@@ -28,6 +28,7 @@ import java.util.List;
 public class CreditBalanceService {
     private static final ZoneId BILLING_ZONE = ZoneId.of("Asia/Seoul");
     private static final int DAILY_CREDIT_RESET_BATCH_SIZE = 500;
+    private static final int MAX_DAILY_CREDIT_RESET_ITERATIONS = 100;
 
     private final CreditBalanceRepository creditBalanceRepository;
     private final CreditBalanceCreator creditBalanceCreator;
@@ -151,10 +152,13 @@ public class CreditBalanceService {
         List<Long> expiredCreditIds = creditBalanceRepository.findExpiredDailyCreditIds(
                 now, DAILY_CREDIT_RESET_BATCH_SIZE);
 
-        int processedCount = 0;
         int totalProcessed = 0;
+        int iteration = 0;
 
-        while (!expiredCreditIds.isEmpty()) {
+        while (!expiredCreditIds.isEmpty() && iteration < MAX_DAILY_CREDIT_RESET_ITERATIONS) {
+            iteration++;
+            int processedCount = 0;
+
             for (Long creditBalanceId : expiredCreditIds) {
                 if (resetDailyCreditInNewTransaction(creditBalanceId, now)) {
                     processedCount++;
@@ -168,7 +172,11 @@ public class CreditBalanceService {
             // 다음 배치 조회
             expiredCreditIds = creditBalanceRepository.findExpiredDailyCreditIds(
                     now, DAILY_CREDIT_RESET_BATCH_SIZE);
-            processedCount = 0;
+        }
+
+        if (!expiredCreditIds.isEmpty()) {
+            log.warn("[DailyCredit] 최대 반복 횟수 초과로 배치 중단: iteration={}, remainingBatchSize={}, totalProcessed={}",
+                    iteration, expiredCreditIds.size(), totalProcessed);
         }
 
         log.info("[DailyCredit] 일일 크레딧 초기화 스케줄러 완료: totalProcessed={}", totalProcessed);

--- a/src/main/java/com/proovy/domain/credit/service/CreditBalanceService.java
+++ b/src/main/java/com/proovy/domain/credit/service/CreditBalanceService.java
@@ -10,22 +10,29 @@ import com.proovy.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class CreditBalanceService {
     private static final ZoneId BILLING_ZONE = ZoneId.of("Asia/Seoul");
+    private static final int DAILY_CREDIT_RESET_BATCH_SIZE = 500;
 
     private final CreditBalanceRepository creditBalanceRepository;
     private final CreditBalanceCreator creditBalanceCreator;
     private final CreditHistoryRepository creditHistoryRepository;
+    private final PlatformTransactionManager transactionManager;
 
     @Transactional
     public CreditBalance getOrCreateBalance(Long userId) {
@@ -129,6 +136,76 @@ public class CreditBalanceService {
             creditBalanceCreator.createInitialBalance(userId, freeCredit);
         } catch (DataIntegrityViolationException e) {
             log.warn("크레딧 잔액 동시 생성 감지, userId={}", userId);
+        }
+    }
+
+    /**
+     * 매일 0시에 만료된 일일 크레딧 초기화 (Asia/Seoul 기준)
+     */
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Transactional(readOnly = true)
+    public void resetExpiredDailyCredits() {
+        LocalDateTime now = nowInBillingZone();
+        log.info("[DailyCredit] 일일 크레딧 초기화 스케줄러 시작: {}", now);
+
+        List<Long> expiredCreditIds = creditBalanceRepository.findExpiredDailyCreditIds(
+                now, DAILY_CREDIT_RESET_BATCH_SIZE);
+
+        int processedCount = 0;
+        int totalProcessed = 0;
+
+        while (!expiredCreditIds.isEmpty()) {
+            for (Long creditBalanceId : expiredCreditIds) {
+                if (resetDailyCreditInNewTransaction(creditBalanceId, now)) {
+                    processedCount++;
+                }
+            }
+
+            totalProcessed += processedCount;
+            log.info("[DailyCredit] 일일 크레딧 초기화 배치 완료: batchSize={}, processed={}, total={}",
+                    expiredCreditIds.size(), processedCount, totalProcessed);
+
+            // 다음 배치 조회
+            expiredCreditIds = creditBalanceRepository.findExpiredDailyCreditIds(
+                    now, DAILY_CREDIT_RESET_BATCH_SIZE);
+            processedCount = 0;
+        }
+
+        log.info("[DailyCredit] 일일 크레딧 초기화 스케줄러 완료: totalProcessed={}", totalProcessed);
+    }
+
+    private boolean resetDailyCreditInNewTransaction(Long creditBalanceId, LocalDateTime now) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
+        try {
+            return Boolean.TRUE.equals(transactionTemplate.execute(status -> {
+                CreditBalance balance = creditBalanceRepository.findById(creditBalanceId)
+                        .orElse(null);
+
+                if (balance == null) {
+                    return false;
+                }
+
+                // 이중 체크: 정말 만료되었는지 확인
+                if (balance.getDailyExpiresAt() == null || balance.getDailyExpiresAt().isAfter(now)) {
+                    return false;
+                }
+
+                // 일일 크레딧 초기화
+                LocalDateTime nextResetAt = nextDailyResetAt(now);
+                balance.resetDailyCredit(nextResetAt);
+                creditBalanceRepository.save(balance);
+
+                log.debug("[DailyCredit] 일일 크레딧 초기화: userId={}, limit={}, nextResetAt={}",
+                        balance.getUser().getId(), balance.getDailyFreeLimit(), nextResetAt);
+
+                return true;
+            }));
+        } catch (Exception e) {
+            log.warn("[DailyCredit] 일일 크레딧 초기화 실패: creditBalanceId={}, error={}",
+                    creditBalanceId, e.getMessage());
+            return false;
         }
     }
 

--- a/src/main/java/com/proovy/domain/user/repository/UserPlanRepository.java
+++ b/src/main/java/com/proovy/domain/user/repository/UserPlanRepository.java
@@ -102,6 +102,24 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, Long> {
         return findDueScheduledChangeIds(now, PageRequest.of(0, batchSize));
     }
 
+    /**
+     * 자동 갱신 대상 플랜 ID 목록 조회 (canceledAt == null, expiredAt <= now)
+     */
+    @Query("""
+            SELECT up.id FROM UserPlan up
+            WHERE up.isActive = true
+              AND up.canceledAt IS NULL
+              AND up.expiredAt IS NOT NULL
+              AND up.expiredAt <= :now
+              AND up.planType != 'FREE'
+            ORDER BY up.expiredAt ASC, up.id ASC
+            """)
+    List<Long> findDueAutoRenewIds(@Param("now") LocalDateTime now, Pageable pageable);
+
+    default List<Long> findDueAutoRenewIds(LocalDateTime now, int batchSize) {
+        return findDueAutoRenewIds(now, PageRequest.of(0, batchSize));
+    }
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT up FROM UserPlan up WHERE up.id = :userPlanId")
     Optional<UserPlan> findByIdWithLock(@Param("userPlanId") Long userPlanId);

--- a/src/main/java/com/proovy/domain/user/service/SubscriptionService.java
+++ b/src/main/java/com/proovy/domain/user/service/SubscriptionService.java
@@ -117,6 +117,9 @@ public class SubscriptionService {
         return SubscriptionResponse.from(activePlan);
     }
 
+    /**
+     * 예약된 플랜 변경 처리 (플랜 취소 → FREE 전환)
+     */
     @Scheduled(fixedDelayString = "${proovy.subscription.plan-transition-fixed-delay-ms:60000}")
     @Transactional(readOnly = true)
     public void processDuePlanTransitions() {
@@ -132,6 +135,27 @@ public class SubscriptionService {
 
         if (!duePlanIds.isEmpty()) {
             log.info("예약된 플랜 변경 처리 완료: requestedCount={}, processedCount={}", duePlanIds.size(), processedCount);
+        }
+    }
+
+    /**
+     * 자동 갱신 처리 (같은 플랜으로 1개월 연장)
+     */
+    @Scheduled(fixedDelayString = "${proovy.subscription.auto-renew-fixed-delay-ms:60000}")
+    @Transactional(readOnly = true)
+    public void processAutoRenewals() {
+        LocalDateTime now = nowInBillingZone();
+        List<Long> autoRenewPlanIds = userPlanRepository.findDueAutoRenewIds(now, PLAN_TRANSITION_BATCH_SIZE);
+        int processedCount = 0;
+
+        for (Long planId : autoRenewPlanIds) {
+            if (processAutoRenewInNewTransaction(planId, now)) {
+                processedCount++;
+            }
+        }
+
+        if (!autoRenewPlanIds.isEmpty()) {
+            log.info("자동 갱신 처리 완료: requestedCount={}, processedCount={}", autoRenewPlanIds.size(), processedCount);
         }
     }
 
@@ -255,6 +279,70 @@ public class SubscriptionService {
                 && plan.getCanceledAt() != null
                 && plan.getExpiredAt() != null
                 && !plan.getExpiredAt().isAfter(now);
+    }
+
+    private boolean isDueAutoRenew(UserPlan plan, LocalDateTime now) {
+        return Boolean.TRUE.equals(plan.getIsActive())
+                && plan.getCanceledAt() == null
+                && plan.getExpiredAt() != null
+                && !plan.getExpiredAt().isAfter(now)
+                && plan.getPlanType() != PlanType.FREE;
+    }
+
+    private boolean processAutoRenewInNewTransaction(Long planId, LocalDateTime now) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
+        try {
+            return Boolean.TRUE.equals(transactionTemplate.execute(status -> {
+                UserPlan oldPlan = userPlanRepository.findByIdWithLock(planId)
+                        .filter(plan -> isDueAutoRenew(plan, now))
+                        .orElse(null);
+
+                if (oldPlan == null) {
+                    return false;
+                }
+
+                applyAutoRenew(oldPlan, now);
+                return true;
+            }));
+        } catch (DataIntegrityViolationException e) {
+            log.warn("자동 갱신 충돌 감지: userPlanId={}", planId, e);
+            return false;
+        } catch (RuntimeException e) {
+            log.warn("자동 갱신 처리 실패: userPlanId={}", planId, e);
+            return false;
+        }
+    }
+
+    private void applyAutoRenew(UserPlan oldPlan, LocalDateTime now) {
+        if (oldPlan.getId() == null || oldPlan.getPlanType() == PlanType.FREE) {
+            return;
+        }
+
+        PlanType planType = oldPlan.getPlanType();
+        User user = oldPlan.getUser();
+        LocalDateTime renewalStartAt = oldPlan.getExpiredAt() != null ? oldPlan.getExpiredAt() : now;
+
+        // 1. 기존 플랜 비활성화
+        oldPlan.deactivate();
+        userPlanRepository.flush();
+
+        // 2. 같은 플랜으로 새 플랜 생성 (1개월 연장)
+        UserPlan newPlan = buildNextActivePlan(user, planType, renewalStartAt);
+        UserPlan savedPlan = userPlanRepository.save(newPlan);
+        userPlanRepository.flush();
+
+        // 3. 월간 크레딧 부여
+        creditBalanceService.grantMonthlyCredit(
+                user.getId(),
+                planType,
+                savedPlan.getId(),
+                planType.getMonthlyCreditLimit()
+        );
+
+        log.info("자동 갱신 완료: userId={}, planType={}, oldPlanId={}, newPlanId={}, renewalStartAt={}",
+                user.getId(), planType, oldPlan.getId(), savedPlan.getId(), renewalStartAt);
     }
 
     private UserPlan buildNextActivePlan(User user, PlanType planType, LocalDateTime startedAt) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -35,6 +35,11 @@ spring:
       # SSE 스트리밍 요청은 장시간 연결이 유지되므로 타임아웃을 해제한다.
       request-timeout: -1
 
+  task:
+    scheduling:
+      pool:
+        size: 3
+
 springdoc:
   swagger-ui:
     tagsSorter: alpha


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #169 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

### 1) UserPlanRepository 수정
- 자동 갱신 대상 플랜을 조회하는 메서드 추가:
  - `findDueAutoRenewIds(now, batchSize)`: canceledAt이 `null`인 만료된 플랜 조회

### 2) SubscriptionService 수정
- 자동 갱신 스케줄러 추가:
  - 60초마다 실행되어 자동 갱신 대상 플랜을 처리
  - 기존 플랜 비활성화 후 같은 플랜으로 새 플랜 생성 및 크레딧 재부여

### 3) CreditBalanceRepository 수정
- 만료된 일일 크레딧을 배치 처리하는 메서드 추가:
  - `findExpiredDailyCreditIds(now, limit)`: 배치 처리용 쿼리 추가

### 4) CreditBalanceService 수정
- 일일 크레딧 초기화 스케줄러 추가:
  - 매일 0시에 자동 실행되어 일일 크레딧을 초기화
  - 만료된 크레딧을 가진 사용자들을 500명씩 처리

### 5) 동작 흐름
- 자동 갱신 대상은 취소되지 않은 플랜으로, 30일 후 같은 플랜으로 1개월 연장되고 크레딧 재부여.
- 취소된 플랜은 FREE 플랜으로 전환.

## 📸 스크린샷



## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 자동 갱신은 매일 0시에 자동으로 실행되며, 배치 처리로 성능 최적화가 가능합니다.
- 취소된 플랜은 FREE 플랜으로 전환됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 만료된 일일 크레딧의 자동 리셋(매일 자정 Asia/Seoul) 추가
  * 구독 플랜 자동 갱신 기능 추가

* **Improvements**
  * 대량 처리 최적화로 배치 기반의 안정적 대량 작업 수행
  * 개별 항목별 격리 처리로 자동 작업의 신뢰성 향상

* **Chores**
  * 정기 작업용 스레드 풀 구성 추가 (스케줄링 안정성 개선)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->