### PR TITLE
[Fix] 채팅 검색 기능 개선

### DIFF
--- a/src/main/java/com/proovy/domain/conversation/config/ChatMessageTsvBackfillRunner.java
+++ b/src/main/java/com/proovy/domain/conversation/config/ChatMessageTsvBackfillRunner.java
@@ -1,0 +1,86 @@
+package com.proovy.domain.conversation.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * chat_messages.content_tsv 컬럼 백필을 위한 ApplicationRunner
+ *
+ * Flyway 트랜잭션 내에서 배치 처리 시 SKIP LOCKED가 무의미하므로
+ * 서버 시작 시 autocommit 모드로 별도 실행
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatMessageTsvBackfillRunner implements ApplicationRunner {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final TransactionTemplate transactionTemplate;
+
+    private static final int BATCH_SIZE = 500;
+    private static final int SLEEP_MS = 50;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        backfillContentTsv();
+    }
+
+    private void backfillContentTsv() {
+        // 백필이 필요한 행이 있는지 먼저 확인
+        Integer nullCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*)::int FROM chat_messages WHERE content_tsv IS NULL",
+                Integer.class
+        );
+
+        if (nullCount == null || nullCount == 0) {
+            log.info("[ChatMessageTsvBackfill] No rows need backfill, skipping");
+            return;
+        }
+
+        log.info("[ChatMessageTsvBackfill] Starting backfill for {} rows", nullCount);
+
+        int totalUpdated = 0;
+
+        while (true) {
+            // 각 배치를 별도 트랜잭션으로 실행 (autocommit 효과)
+            Integer updated = transactionTemplate.execute(status -> {
+                return jdbcTemplate.update("""
+                    UPDATE chat_messages
+                    SET content_tsv = to_tsvector('simple', COALESCE(content->>'text', ''))
+                    WHERE chat_message_id IN (
+                        SELECT chat_message_id FROM chat_messages
+                        WHERE content_tsv IS NULL
+                        LIMIT ?
+                        FOR UPDATE SKIP LOCKED
+                    )
+                    """, BATCH_SIZE);
+            });
+
+            if (updated == null || updated == 0) {
+                break;
+            }
+
+            totalUpdated += updated;
+
+            if (totalUpdated % 5000 == 0) {
+                log.info("[ChatMessageTsvBackfill] Progress: {} rows updated", totalUpdated);
+            }
+
+            // 다른 트랜잭션에 기회 제공
+            try {
+                Thread.sleep(SLEEP_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("[ChatMessageTsvBackfill] Interrupted, stopping backfill");
+                break;
+            }
+        }
+
+        log.info("[ChatMessageTsvBackfill] Completed. Total updated: {} rows", totalUpdated);
+    }
+}

--- a/src/main/java/com/proovy/domain/conversation/repository/ChatMessageRepository.java
+++ b/src/main/java/com/proovy/domain/conversation/repository/ChatMessageRepository.java
@@ -74,13 +74,14 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     // =============================================
 
     /**
-     * Full-Text Search: content->>'text' 기반 검색 (영문/숫자)
+     * Full-Text Search: content_tsv 컬럼 기반 검색 (영문/숫자)
+     * content_tsv는 트리거에 의해 자동 업데이트됨 (V30 마이그레이션)
      */
     @Query(value = """
             SELECT cm.* FROM chat_messages cm
             JOIN notes n ON cm.note_id = n.note_id
             WHERE n.user_id = :userId
-              AND to_tsvector('simple', COALESCE(cm.content->>'text', '')) @@ plainto_tsquery('simple', :query)
+              AND cm.content_tsv @@ plainto_tsquery('simple', :query)
               AND (CAST(:noteId AS BIGINT) IS NULL OR cm.note_id = CAST(:noteId AS BIGINT))
               AND (CAST(:startDate AS DATE) IS NULL OR DATE(cm.created_at) >= CAST(:startDate AS DATE))
               AND (CAST(:endDate AS DATE) IS NULL OR DATE(cm.created_at) <= CAST(:endDate AS DATE))
@@ -90,7 +91,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             SELECT COUNT(*) FROM chat_messages cm
             JOIN notes n ON cm.note_id = n.note_id
             WHERE n.user_id = :userId
-              AND to_tsvector('simple', COALESCE(cm.content->>'text', '')) @@ plainto_tsquery('simple', :query)
+              AND cm.content_tsv @@ plainto_tsquery('simple', :query)
               AND (CAST(:noteId AS BIGINT) IS NULL OR cm.note_id = CAST(:noteId AS BIGINT))
               AND (CAST(:startDate AS DATE) IS NULL OR DATE(cm.created_at) >= CAST(:startDate AS DATE))
               AND (CAST(:endDate AS DATE) IS NULL OR DATE(cm.created_at) <= CAST(:endDate AS DATE))

--- a/src/main/resources/db/migration/V30__fix_chat_messages_fulltext_search.sql
+++ b/src/main/resources/db/migration/V30__fix_chat_messages_fulltext_search.sql
@@ -1,0 +1,65 @@
+-- ==========================================================
+-- V30: chat_messages Full-Text Search 수정
+-- 문제: content_tsv 트리거 누락, 인덱스 미활용
+-- ==========================================================
+
+-- 1. content_tsv 자동 업데이트 트리거 함수 생성
+-- JSONB content에서 'text' 필드를 추출하여 tsvector 생성
+CREATE OR REPLACE FUNCTION chat_messages_content_tsv_update()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- content JSONB에서 'text' 필드 추출 후 tsvector 생성
+    -- 'simple' 설정: 언어 의존성 없이 토큰화 (한글 호환)
+    NEW.content_tsv := to_tsvector('simple', COALESCE(NEW.content->>'text', ''));
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 2. 트리거 생성 (INSERT/UPDATE 시 자동 업데이트)
+DROP TRIGGER IF EXISTS trg_chat_messages_content_tsv ON chat_messages;
+CREATE TRIGGER trg_chat_messages_content_tsv
+    BEFORE INSERT OR UPDATE OF content ON chat_messages
+    FOR EACH ROW
+    EXECUTE FUNCTION chat_messages_content_tsv_update();
+
+-- 3. pg_trgm 인덱스 추가 (한글 ILIKE 검색 최적화)
+-- content->>'text'에 대한 표현식 인덱스
+CREATE INDEX IF NOT EXISTS idx_chat_messages_content_text_trgm
+ON chat_messages USING GIN((content->>'text') gin_trgm_ops);
+
+-- 4. 기존 데이터 백필 (배치 처리로 테이블 락 방지)
+-- 500건씩 배치로 처리하여 장시간 락 방지 및 502 에러 방지
+DO $$
+DECLARE
+    batch_size INT := 500;
+    updated_count INT;
+    total_updated INT := 0;
+BEGIN
+    RAISE NOTICE 'Starting content_tsv backfill...';
+
+    LOOP
+        UPDATE chat_messages
+        SET content_tsv = to_tsvector('simple', COALESCE(content->>'text', ''))
+        WHERE chat_message_id IN (
+            SELECT chat_message_id FROM chat_messages
+            WHERE content_tsv IS NULL
+            LIMIT batch_size
+            FOR UPDATE SKIP LOCKED
+        );
+
+        GET DIAGNOSTICS updated_count = ROW_COUNT;
+        total_updated := total_updated + updated_count;
+
+        -- 더 이상 업데이트할 행이 없으면 종료
+        EXIT WHEN updated_count = 0;
+
+        -- 각 배치 후 짧은 대기 (다른 트랜잭션에 기회 제공)
+        PERFORM pg_sleep(0.05);
+    END LOOP;
+
+    RAISE NOTICE 'Backfill completed. Total updated: %', total_updated;
+END $$;
+
+-- 5. 검색 성능을 위한 복합 인덱스 (user_id를 통한 필터링 최적화)
+CREATE INDEX IF NOT EXISTS idx_chat_messages_note_id_content_tsv
+ON chat_messages USING GIN(content_tsv) WHERE note_id IS NOT NULL;

--- a/src/main/resources/db/migration/V30__fix_chat_messages_fulltext_search.sql
+++ b/src/main/resources/db/migration/V30__fix_chat_messages_fulltext_search.sql
@@ -27,39 +27,9 @@ CREATE TRIGGER trg_chat_messages_content_tsv
 CREATE INDEX IF NOT EXISTS idx_chat_messages_content_text_trgm
 ON chat_messages USING GIN((content->>'text') gin_trgm_ops);
 
--- 4. 기존 데이터 백필 (배치 처리로 테이블 락 방지)
--- 500건씩 배치로 처리하여 장시간 락 방지 및 502 에러 방지
-DO $$
-DECLARE
-    batch_size INT := 500;
-    updated_count INT;
-    total_updated INT := 0;
-BEGIN
-    RAISE NOTICE 'Starting content_tsv backfill...';
-
-    LOOP
-        UPDATE chat_messages
-        SET content_tsv = to_tsvector('simple', COALESCE(content->>'text', ''))
-        WHERE chat_message_id IN (
-            SELECT chat_message_id FROM chat_messages
-            WHERE content_tsv IS NULL
-            LIMIT batch_size
-            FOR UPDATE SKIP LOCKED
-        );
-
-        GET DIAGNOSTICS updated_count = ROW_COUNT;
-        total_updated := total_updated + updated_count;
-
-        -- 더 이상 업데이트할 행이 없으면 종료
-        EXIT WHEN updated_count = 0;
-
-        -- 각 배치 후 짧은 대기 (다른 트랜잭션에 기회 제공)
-        PERFORM pg_sleep(0.05);
-    END LOOP;
-
-    RAISE NOTICE 'Backfill completed. Total updated: %', total_updated;
-END $$;
-
--- 5. 검색 성능을 위한 복합 인덱스 (user_id를 통한 필터링 최적화)
+-- 4. note_id가 있는 메시지에 대한 content_tsv GIN 인덱스 (검색 시 note_id IS NOT NULL 조건 최적화)
 CREATE INDEX IF NOT EXISTS idx_chat_messages_note_id_content_tsv
 ON chat_messages USING GIN(content_tsv) WHERE note_id IS NOT NULL;
+
+-- NOTE: 기존 데이터 백필은 ChatMessageTsvBackfillRunner에서 autocommit 모드로 별도 실행됨
+-- Flyway 트랜잭션 내에서 배치 처리 시 SKIP LOCKED가 무의미하므로 분리함


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #171 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

1. 마이그레이션 V30 생성 (V30__fix_chat_messages_fulltext_search.sql)
  - content_tsv 자동 업데이트 트리거 추가
  - 한글 검색용 pg_trgm 인덱스 추가 (content->>'text')
  - 기존 데이터 백필 (500건씩 배치 처리로 락 방지)

  2. Repository 쿼리 최적화 (ChatMessageRepository.java:83)
  -- 변경 전 (매번 tsvector 계산 - 느림)
  to_tsvector('simple', COALESCE(cm.content->>'text', '')) @@ plainto_tsquery(...)

  -- 변경 후 (인덱스 활용 - 빠름)
  cm.content_tsv @@ plainto_tsquery(...)

 3. 502 에러 방지 전략

  - 500건씩 배치 처리 + FOR UPDATE SKIP LOCKED
  - 배치 간 pg_sleep(0.05) 대기
  - 장시간 테이블 락 방지

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

  배포 후 동작

  1. 서버 재시작 시 Flyway가 V30 마이그레이션 자동 실행
  2. 기존 content_tsv NULL 데이터 백필
  3. 새 메시지 INSERT/UPDATE 시 트리거가 content_tsv 자동 갱신
  4. 검색 쿼리가 GIN 인덱스 활용하여 빠른 검색


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 채팅 메시지에 대한 자동 색인 및 배경 백필이 추가되어 기존 메시지까지 검색 대상으로 포함됩니다.
* **버그 수정**
  * 채팅 메시지 전체검색의 정확도 및 성능을 개선하여 한글을 포함한 다양한 언어에서 더 일관된 검색 결과를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->