### PR TITLE
[Fix] 채팅 검색 기능 개선_2

### DIFF
--- a/src/main/java/com/proovy/domain/conversation/repository/ChatMessageRepository.java
+++ b/src/main/java/com/proovy/domain/conversation/repository/ChatMessageRepository.java
@@ -76,12 +76,13 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     /**
      * Full-Text Search: content_tsv 컬럼 기반 검색 (영문/숫자)
      * content_tsv는 트리거에 의해 자동 업데이트됨 (V30 마이그레이션)
+     * COALESCE로 content_tsv가 NULL인 경우 to_tsvector 폴백 처리
      */
     @Query(value = """
             SELECT cm.* FROM chat_messages cm
             JOIN notes n ON cm.note_id = n.note_id
             WHERE n.user_id = :userId
-              AND cm.content_tsv @@ plainto_tsquery('simple', :query)
+              AND COALESCE(cm.content_tsv, to_tsvector('simple', COALESCE(cm.content->>'text', ''))) @@ plainto_tsquery('simple', :query)
               AND (CAST(:noteId AS BIGINT) IS NULL OR cm.note_id = CAST(:noteId AS BIGINT))
               AND (CAST(:startDate AS DATE) IS NULL OR DATE(cm.created_at) >= CAST(:startDate AS DATE))
               AND (CAST(:endDate AS DATE) IS NULL OR DATE(cm.created_at) <= CAST(:endDate AS DATE))
@@ -91,7 +92,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             SELECT COUNT(*) FROM chat_messages cm
             JOIN notes n ON cm.note_id = n.note_id
             WHERE n.user_id = :userId
-              AND cm.content_tsv @@ plainto_tsquery('simple', :query)
+              AND COALESCE(cm.content_tsv, to_tsvector('simple', COALESCE(cm.content->>'text', ''))) @@ plainto_tsquery('simple', :query)
               AND (CAST(:noteId AS BIGINT) IS NULL OR cm.note_id = CAST(:noteId AS BIGINT))
               AND (CAST(:startDate AS DATE) IS NULL OR DATE(cm.created_at) >= CAST(:startDate AS DATE))
               AND (CAST(:endDate AS DATE) IS NULL OR DATE(cm.created_at) <= CAST(:endDate AS DATE))

--- a/src/main/java/com/proovy/domain/conversation/service/ConversationQueryServiceImpl.java
+++ b/src/main/java/com/proovy/domain/conversation/service/ConversationQueryServiceImpl.java
@@ -25,7 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -41,9 +40,6 @@ public class ConversationQueryServiceImpl implements ConversationQueryService {
 
     private static final int PRESIGNED_URL_DURATION_MINUTES = 15;
     private static final Set<String> ALLOWED_CANVAS_MIME_TYPES = Set.of("image/png", "image/jpeg", "image/webp");
-
-    // 한글 검색 패턴 (한글이 포함되어 있으면 pg_trgm 사용)
-    private static final Pattern KOREAN_PATTERN = Pattern.compile("[가-힣ㄱ-ㅎㅏ-ㅣ]");
 
     @Override
     @Transactional
@@ -195,7 +191,8 @@ public class ConversationQueryServiceImpl implements ConversationQueryService {
     }
 
     /**
-     * ChatMessage 기반 Full-Text Search 실행
+     * ChatMessage 기반 검색 실행
+     * pg_trgm ILIKE 검색으로 통일 (한글/영문 모두 부분 문자열 검색 지원)
      */
     private Page<ChatMessage> executeChatMessageSearch(
             Long userId,
@@ -205,17 +202,9 @@ public class ConversationQueryServiceImpl implements ConversationQueryService {
             LocalDate endDate,
             Pageable pageable
     ) {
-        boolean containsKorean = KOREAN_PATTERN.matcher(query).find();
-
-        if (containsKorean) {
-            // 한글 검색: pg_trgm ILIKE
-            return chatMessageRepository.searchByTrigram(
-                    userId, query, noteId, startDate, endDate, pageable);
-        } else {
-            // 영문/숫자 검색: tsvector
-            return chatMessageRepository.searchByFullText(
-                    userId, query, noteId, startDate, endDate, pageable);
-        }
+        // pg_trgm ILIKE 검색 사용 (한글/영문 모두 지원)
+        return chatMessageRepository.searchByTrigram(
+                userId, query, noteId, startDate, endDate, pageable);
     }
 
     /**
@@ -276,19 +265,8 @@ public class ConversationQueryServiceImpl implements ConversationQueryService {
 
         String preview = textContent.length() > 200 ? textContent.substring(0, 200) + "..." : textContent;
 
-        // DB ts_headline 하이라이트 조회 (한글이 아닌 경우에만)
-        String highlight;
-        boolean containsKorean = KOREAN_PATTERN.matcher(query).find();
-        if (!containsKorean) {
-            try {
-                highlight = chatMessageRepository.getSearchHighlight(message.getId(), query);
-            } catch (Exception e) {
-                log.debug("ts_headline 조회 실패, 폴백 사용: {}", e.getMessage());
-                highlight = extractHighlight(textContent, query);
-            }
-        } else {
-            highlight = extractHighlight(textContent, query);
-        }
+        // 검색어 주변 하이라이트 추출
+        String highlight = extractHighlight(textContent, query);
 
         return ConversationSearchResponse.MessageInfo.builder()
                 .text(textContent)

--- a/src/main/java/com/proovy/domain/note/repository/NoteRepository.java
+++ b/src/main/java/com/proovy/domain/note/repository/NoteRepository.java
@@ -29,13 +29,14 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
 
     /**
      * 노트 제목 또는 파일명으로 검색 (스토리지용)
+     * ILIKE: PostgreSQL case-insensitive LIKE (한글/영문 모두 지원)
      */
     @Query(value = """
             SELECT DISTINCT n.* FROM notes n
             LEFT JOIN assets a ON a.note_id = n.note_id
             WHERE n.user_id = :userId
-              AND (LOWER(n.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
-                   OR LOWER(a.file_name) LIKE LOWER(CONCAT('%', :keyword, '%')))
+              AND (n.title ILIKE '%' || :keyword || '%'
+                   OR a.file_name ILIKE '%' || :keyword || '%')
             ORDER BY n.created_at DESC
             """, nativeQuery = true)
     List<Note> searchByTitleOrFileName(@Param("userId") Long userId, @Param("keyword") String keyword);


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #173 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

1. Conversation 검색 (ConversationQueryServiceImpl.java)
  - Full-text search (tsvector) → ILIKE 검색으로 통일
  - 한글/영문 구분 없이 모두 searchByTrigram 사용
  - 부분 문자열 검색 지원 (예: "안녕"으로 "안녕하세요" 검색 가능)

  2. Storage 검색 (NoteRepository.java)
  -- 변경 전
  LOWER(n.title) LIKE LOWER(CONCAT('%', :keyword, '%'))

  -- 변경 후
  n.title ILIKE '%' || :keyword || '%'
  - PostgreSQL ILIKE 사용 (case-insensitive)

  3. 하이라이트 로직 간소화
  - ts_headline 제거 → extractHighlight 통일
  - 사용하지 않는 KOREAN_PATTERN 제거

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [ ] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * NULL 콘텐츠 처리 개선으로 검색 안정성 강화
  * 대소문자를 구분하지 않는 정확한 노트 및 메시지 검색 지원

* **개선 사항**
  * 검색 엔진 통합으로 더욱 일관되고 신뢰할 수 있는 검색 경험 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->