### PR TITLE
[Fix] 대화 검색/채팅 기록 조회 시 null/undefined 데이터로 프론트 크래시 발생

### DIFF
--- a/src/main/java/com/proovy/domain/conversation/service/ConversationQueryServiceImpl.java
+++ b/src/main/java/com/proovy/domain/conversation/service/ConversationQueryServiceImpl.java
@@ -234,6 +234,14 @@ public class ConversationQueryServiceImpl implements ConversationQueryService {
             ConversationSearchResponse.MessageInfo messageInfo =
                     buildMessageInfoFromChatMessage(message, query);
 
+            // 빈 MessageInfo (null 방지)
+            ConversationSearchResponse.MessageInfo emptyMessageInfo =
+                    ConversationSearchResponse.MessageInfo.builder()
+                            .text("")
+                            .preview("")
+                            .highlight("")
+                            .build();
+
             // 메시지 역할에 따라 userMessage 또는 assistantMessage 설정
             ConversationSearchResponse.ConversationSearchItem.ConversationSearchItemBuilder builder =
                     ConversationSearchResponse.ConversationSearchItem.builder()
@@ -247,7 +255,9 @@ public class ConversationQueryServiceImpl implements ConversationQueryService {
 
             if (message.getRole() == MessageRole.USER) {
                 builder.userMessage(messageInfo);
+                builder.assistantMessage(emptyMessageInfo);
             } else if (message.getRole() == MessageRole.ASSISTANT) {
+                builder.userMessage(emptyMessageInfo);
                 builder.assistantMessage(messageInfo);
             }
 

--- a/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
+++ b/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
@@ -485,12 +485,23 @@ public class NoteServiceImpl implements NoteService {
                     LocalDateTime createdAt = pair.userMessage != null ? pair.userMessage.getCreatedAt() :
                             (pair.assistantMessage != null ? pair.assistantMessage.getCreatedAt() : LocalDateTime.now());
 
+                    // 빈 MessageInfo (null 방지)
+                    NoteDetailResponse.MessageInfo emptyMessageInfo = NoteDetailResponse.MessageInfo.builder()
+                            .messageId(0L)
+                            .content("")
+                            .mentionedAssets(List.of())
+                            .mentionedTools(List.of())
+                            .usedTools(List.of())
+                            .generatedFiles(List.of())
+                            .createdAt(LocalDateTime.now())
+                            .build();
+
                     return NoteDetailResponse.ConversationInfo.builder()
                             .conversationId(conversationId)
-                            .userMessage(pair.userMessage != null ? 
-                                    buildChatMessageInfo(pair.userMessage, finalMessageAssetMap, finalMessageToolMap, true) : null)
-                            .assistantMessage(pair.assistantMessage != null ? 
-                                    buildChatMessageInfo(pair.assistantMessage, finalMessageAssetMap, finalMessageToolMap, false) : null)
+                            .userMessage(pair.userMessage != null ?
+                                    buildChatMessageInfo(pair.userMessage, finalMessageAssetMap, finalMessageToolMap, true) : emptyMessageInfo)
+                            .assistantMessage(pair.assistantMessage != null ?
+                                    buildChatMessageInfo(pair.assistantMessage, finalMessageAssetMap, finalMessageToolMap, false) : emptyMessageInfo)
                             .createdAt(createdAt)
                             .build();
                 })


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #179 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

### 문제 상황

1. 검색 기능 에러
  Cannot read properties of undefined (reading 'length')
  - **원인**: `/api/conversations/search` 응답에서 `userMessage` 또는 `assistantMessage`가 null

2. 채팅 기록 에러
  Cannot read properties of null (reading 'messageId')
  - **원인**: `/api/notes/{noteId}` 응답에서 `conversations[].userMessage` 또는 `conversations[].assistantMessage`가 null

백엔드 수정 완료 

  null 대신 빈 객체를 반환하도록 수정했습니다:
  - `ConversationQueryServiceImpl.java` - 검색 응답
  - `NoteServiceImpl.java` - 채팅 기록 응답

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 대화 검색 및 노트 상세 조회 시 메시지 정보의 null 처리를 개선하여 데이터 안정성을 향상시켰습니다. 빈 메시지 정보로 채워져 모든 경우에 유효한 데이터를 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->