### PR TITLE
[Fix] chat sse final message persist

### DIFF
--- a/src/main/java/com/proovy/domain/conversation/controller/ConversationController.java
+++ b/src/main/java/com/proovy/domain/conversation/controller/ConversationController.java
@@ -121,19 +121,35 @@ public class ConversationController {
         return chatService.streamConversation(userId, request, accessToken)
                 .map(event -> {
                     try {
-                        // ProovyAiStreamEvent를 JSON 문자열로 변환
+                        // ProovyAiStreamEvent를 프론트엔드 형식으로 변환
+                        // 프론트엔드는 data 필드에 {"type":"...", ...} 형태를 기대
                         String eventType = event.getEvent();
-                        String dataJson = convertToJson(event.getData());
-                        
+
+                        // [DONE] 이벤트는 특별 처리
+                        if ("[DONE]".equals(eventType)) {
+                            return ServerSentEvent.<String>builder()
+                                    .data("[DONE]")
+                                    .build();
+                        }
+
+                        // 일반 이벤트: {"type": "...", ...data...} 형태로 병합
+                        java.util.Map<String, Object> payload = new java.util.HashMap<>();
+                        payload.put("type", eventType);
+
+                        // event.getData()의 내용을 payload에 병합
+                        if (event.getData() != null) {
+                            payload.putAll(event.getData());
+                        }
+
+                        String dataJson = convertToJson(payload);
+
                         return ServerSentEvent.<String>builder()
-                                .event(eventType)
                                 .data(dataJson)
                                 .build();
                     } catch (Exception e) {
                         log.error("Failed to build SSE event", e);
                         return ServerSentEvent.<String>builder()
-                                .event("error")
-                                .data("{\"error\":\"Failed to process event\"}")
+                                .data("{\"type\":\"error\",\"content\":\"Failed to process event\"}")
                                 .build();
                     }
                 })

--- a/src/main/java/com/proovy/domain/conversation/controller/ConversationController.java
+++ b/src/main/java/com/proovy/domain/conversation/controller/ConversationController.java
@@ -134,12 +134,12 @@ public class ConversationController {
 
                         // 일반 이벤트: {"type": "...", ...data...} 형태로 병합
                         java.util.Map<String, Object> payload = new java.util.HashMap<>();
-                        payload.put("type", eventType);
-
                         // event.getData()의 내용을 payload에 병합
                         if (event.getData() != null) {
                             payload.putAll(event.getData());
                         }
+                        // event 데이터에 type이 있어도 컨트롤러에서 계산한 eventType이 우선한다.
+                        payload.put("type", eventType);
 
                         String dataJson = convertToJson(payload);
 

--- a/src/main/java/com/proovy/domain/conversation/service/ChatServiceImpl.java
+++ b/src/main/java/com/proovy/domain/conversation/service/ChatServiceImpl.java
@@ -221,13 +221,13 @@ public class ChatServiceImpl implements ChatService {
                         if (contentObj instanceof Map) {
                             @SuppressWarnings("unchecked")
                             Map<String, Object> chatMessage = (Map<String, Object>) contentObj;
-                            String messageType = (String) chatMessage.get("type");
+                            String messageType = Objects.toString(chatMessage.get("type"), null);
 
                             // AI 메시지의 최종 응답을 저장
                             if ("ai".equals(messageType)) {
                                 Object messageContent = chatMessage.get("content");
                                 if (messageContent != null) {
-                                    String finalText = messageContent.toString();
+                                    String finalText = toPersistableText(messageContent);
                                     finalMessageHolder.setLength(0);
                                     finalMessageHolder.append(finalText);
                                     log.debug("[Chat] 최종 AI 메시지 수신 - length: {}", finalText.length());
@@ -411,7 +411,7 @@ public class ChatServiceImpl implements ChatService {
                 Map<String, Object> payload = objectMapper.readValue(trimmed, Map.class);
 
                 // type 필드 추출 (없으면 "message"로 기본 설정)
-                String type = (String) payload.getOrDefault("type", "message");
+                String type = Objects.toString(payload.get("type"), "message");
 
                 log.debug("[Chat] SSE 이벤트 파싱 - type: {}, payload keys: {}", type, payload.keySet());
 
@@ -428,6 +428,19 @@ public class ChatServiceImpl implements ChatService {
                         .build();
             }
         }).filter(event -> event != null); // null 이벤트 필터링
+    }
+
+    private String toPersistableText(Object messageContent) {
+        if (messageContent instanceof String text) {
+            return text;
+        }
+
+        try {
+            return objectMapper.writeValueAsString(messageContent);
+        } catch (Exception e) {
+            log.warn("[Chat] message content JSON 변환 실패, 문자열로 대체", e);
+            return String.valueOf(messageContent);
+        }
     }
 
     /**

--- a/src/main/java/com/proovy/domain/conversation/service/ChatServiceImpl.java
+++ b/src/main/java/com/proovy/domain/conversation/service/ChatServiceImpl.java
@@ -177,6 +177,7 @@ public class ChatServiceImpl implements ChatService {
 
         // 8. SSE 스트리밍 호출
         final StringBuilder contentBuilder = new StringBuilder();
+        final StringBuilder finalMessageHolder = new StringBuilder();
         log.info("[Chat] Proovy-ai 스트리밍 호출 준비 - sessionId: {}, userId: {}",
             chatSession.getId(), userId);
 
@@ -187,7 +188,7 @@ public class ChatServiceImpl implements ChatService {
                     // thread_id 업데이트 (payload 내부에 포함되는 경우)
                     if (data != null && data.containsKey("thread_id")) {
                         String newThreadId = (String) data.get("thread_id");
-                        
+
                         if (newThreadId != null) {
                             if (finalNote != null) {
                                 // Note가 있으면 Note에 threadId 저장
@@ -213,14 +214,46 @@ public class ChatServiceImpl implements ChatService {
                             contentBuilder.append(content.toString());
                         }
                     }
+
+                    // message 이벤트 처리 (Python AI의 최종 응답 포함)
+                    if ("message".equals(event.getEvent()) && data != null) {
+                        Object contentObj = data.get("content");
+                        if (contentObj instanceof Map) {
+                            @SuppressWarnings("unchecked")
+                            Map<String, Object> chatMessage = (Map<String, Object>) contentObj;
+                            String messageType = (String) chatMessage.get("type");
+
+                            // AI 메시지의 최종 응답을 저장
+                            if ("ai".equals(messageType)) {
+                                Object messageContent = chatMessage.get("content");
+                                if (messageContent != null) {
+                                    String finalText = messageContent.toString();
+                                    finalMessageHolder.setLength(0);
+                                    finalMessageHolder.append(finalText);
+                                    log.debug("[Chat] 최종 AI 메시지 수신 - length: {}", finalText.length());
+                                }
+                            }
+                        }
+                    }
                 })
                 .doOnComplete(() -> {
                     // 스트리밍 완료 시 최종 내용 저장
-                    String finalText = contentBuilder.toString();
+                    // 우선순위: 1. 최종 AI 메시지 (type=message, ai) 2. 토큰 누적
+                    String finalText = finalMessageHolder.length() > 0
+                        ? finalMessageHolder.toString()
+                        : contentBuilder.toString();
+
+                    if (finalText.isEmpty()) {
+                        log.warn("[Chat] 스트리밍 완료했으나 내용이 비어있음 - messageId: {}", savedAiMessage.getId());
+                    }
+
                     ObjectNode finalContent = objectMapper.createObjectNode();
                     finalContent.put("text", finalText);
                     savedAiMessage.updateContentAndStatus(finalContent, MessageStatus.COMPLETED);
                     chatMessageRepository.save(savedAiMessage);
+
+                    log.info("[Chat] AI 메시지 저장 완료 - messageId: {}, length: {}",
+                        savedAiMessage.getId(), finalText.length());
 
                     // 크레딧 차감
                     if (request.getChosenFeatures() != null && !request.getChosenFeatures().isEmpty()) {
@@ -346,17 +379,13 @@ public class ChatServiceImpl implements ChatService {
     private Mono<ProovyAiStreamEvent> parseSseEvent(String rawEvent) {
         return Mono.fromCallable(() -> {
             try {
-                if (rawEvent == null) {
-                    return ProovyAiStreamEvent.builder()
-                            .event("message")
-                            .data(Collections.emptyMap())
-                            .build();
+                if (rawEvent == null || rawEvent.trim().isEmpty()) {
+                    return null; // null 이벤트는 건너뛰기
                 }
 
                 String trimmed = rawEvent.trim();
 
-                // WebClient 가 TEXT_EVENT_STREAM 을 파싱하면 보통 data payload 만 넘어온다.
-                // [DONE] 토큰은 그대로 문자열로 온다고 가정한다.
+                // [DONE] 토큰 처리
                 if ("[DONE]".equals(trimmed)) {
                     return ProovyAiStreamEvent.builder()
                             .event("[DONE]")
@@ -364,28 +393,41 @@ public class ChatServiceImpl implements ChatService {
                             .build();
                 }
 
-                // 혹시 "data: {..}" 형태로 온 경우를 대비해 prefix 제거
+                // "data: {..}" 형태인 경우 prefix 제거
                 if (trimmed.startsWith("data:")) {
                     trimmed = trimmed.substring(5).trim();
+
+                    // data: [DONE] 형태도 처리
+                    if ("[DONE]".equals(trimmed)) {
+                        return ProovyAiStreamEvent.builder()
+                                .event("[DONE]")
+                                .data(Collections.emptyMap())
+                                .build();
+                    }
                 }
 
-                // 나머지는 모두 JSON payload 로 간주
+                // JSON payload 파싱
+                @SuppressWarnings("unchecked")
                 Map<String, Object> payload = objectMapper.readValue(trimmed, Map.class);
+
+                // type 필드 추출 (없으면 "message"로 기본 설정)
                 String type = (String) payload.getOrDefault("type", "message");
+
+                log.debug("[Chat] SSE 이벤트 파싱 - type: {}, payload keys: {}", type, payload.keySet());
 
                 return ProovyAiStreamEvent.builder()
                         .event(type)
                         .data(payload)
                         .build();
-                        
+
             } catch (Exception e) {
-                log.warn("Failed to parse SSE event: {}", rawEvent, e);
+                log.warn("[Chat] SSE 이벤트 파싱 실패: {}", rawEvent, e);
                 return ProovyAiStreamEvent.builder()
                         .event("error")
-                        .data(Map.of("error", "Failed to parse event"))
+                        .data(Map.of("error", "Failed to parse event", "raw", rawEvent))
                         .build();
             }
-        });
+        }).filter(event -> event != null); // null 이벤트 필터링
     }
 
     /**


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #176 
- Closes #177 
- Closes #178 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 최종 응답 처리 개선
  - Python AI의 최종 message 이벤트(type="message", content.type="ai")를 수신하여 최종 텍스트로 저장
  - 저장 우선순위 적용: 최종 AI message > 토큰 누적 결과
  - 스트리밍 완료 시 content가 비어있으면 warn 로그로 추적 가능하게 처리
- SSE 전송 포맷 정합화
  - 프론트 기대 형태로 `data: {"type":"...", ...payload}` 형태로 통일
  - `[DONE]` 이벤트는 `data: [DONE]`로 특별 처리
- SSE 파싱 안정화
  - null/빈 이벤트 스킵
  - `data:` prefix 및 `data: [DONE]` 케이스 처리
  - 파싱 실패 시 raw 포함하여 경고 로그 강화

## 📸 스크린샷



## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 오류 발생 시 더 명확한 오류 메시지 전달 방식 개선
  * AI 응답 처리 및 스트리밍 데이터 핸들링 안정성 강화
  * 최종 메시지 캡처 로직 개선으로 응답 정확성 향상

* **기타 개선사항**
  * 내부 이벤트 처리 로직 최적화 및 디버깅 정보 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->