### PR TITLE
[Fix] MessageAsset 저장 전 ChatMessage flush로 ID 확보

### DIFF
--- a/src/main/java/com/proovy/domain/conversation/service/ChatServiceImpl.java
+++ b/src/main/java/com/proovy/domain/conversation/service/ChatServiceImpl.java
@@ -139,6 +139,7 @@ public class ChatServiceImpl implements ChatService {
                     .status(MessageStatus.COMPLETED)
                     .build();
             ChatMessage savedUserMessage = chatMessageRepository.save(userMessage);
+            chatMessageRepository.flush(); // ID 확보 후 MessageAsset 저장 가능
 
             // 4-1. 메시지-자산 연결 저장 (mentionedAssetIds + canvasImageIds)
             List<Long> allAssetIds = new ArrayList<>();


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #186 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- `ChatServiceImpl`에서 사용자 메시지 저장 직후 `chatMessageRepository.flush()` 추가
  - save()만으로는 ID가 즉시 확정되지 않아 `savedUserMessage.getId()`가 null일 수 있음
  - flush()로 ID 확정 후 MessageAsset 저장이 가능하도록 보장

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* **버그 수정**
  * 메시지 저장 시 관련 첨부파일이 올바르게 저장되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->