### PR TITLE
[Fix] 크레딧 시간대 서울 고정 및 만료 일일크레딧 접근 시 즉시 리셋

### DIFF
--- a/src/main/java/com/proovy/ProovyApiApplication.java
+++ b/src/main/java/com/proovy/ProovyApiApplication.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableJpaAuditing
+@EnableJpaAuditing(dateTimeProviderRef = "seoulDateTimeProvider")
 @EnableScheduling
 @EnableAsync
 @SpringBootApplication

--- a/src/main/java/com/proovy/domain/credit/service/CreditBalanceService.java
+++ b/src/main/java/com/proovy/domain/credit/service/CreditBalanceService.java
@@ -37,23 +37,29 @@ public class CreditBalanceService {
 
     @Transactional
     public CreditBalance getOrCreateBalance(Long userId) {
-        return creditBalanceRepository.findByUserId(userId)
+        CreditBalance balance = creditBalanceRepository.findByUserId(userId)
                 .orElseGet(() -> {
                     // 가입 보너스는 signup 경로에서만 지급됩니다.
                     createInitialBalanceSafely(userId, 0);
                     return creditBalanceRepository.findByUserId(userId)
                             .orElseThrow(() -> new BusinessException(ErrorCode.CREDIT4041));
                 });
+
+        refreshDailyCreditIfExpired(balance, nowInBillingZone());
+        return balance;
     }
 
     @Transactional
     public CreditBalance getOrCreateBalanceForUpdate(Long userId) {
-        return creditBalanceRepository.findByUserIdForUpdate(userId)
+        CreditBalance balance = creditBalanceRepository.findByUserIdForUpdate(userId)
                 .orElseGet(() -> {
                     createInitialBalanceSafely(userId, 0);
                     return creditBalanceRepository.findByUserIdForUpdate(userId)
                             .orElseThrow(() -> new BusinessException(ErrorCode.CREDIT4041));
                 });
+
+        refreshDailyCreditIfExpired(balance, nowInBillingZone());
+        return balance;
     }
 
     @Transactional
@@ -223,5 +229,19 @@ public class CreditBalanceService {
 
     private LocalDateTime nextDailyResetAt(LocalDateTime now) {
         return now.toLocalDate().plusDays(1).atStartOfDay();
+    }
+
+    private void refreshDailyCreditIfExpired(CreditBalance balance, LocalDateTime now) {
+        LocalDateTime expiresAt = balance.getDailyExpiresAt();
+        if (expiresAt != null && expiresAt.isAfter(now)) {
+            return;
+        }
+
+        LocalDateTime nextResetAt = nextDailyResetAt(now);
+        balance.resetDailyCredit(nextResetAt);
+        creditBalanceRepository.save(balance);
+
+        log.info("[DailyCredit] 접근 시 만료 감지로 즉시 초기화: userId={}, prevExpiresAt={}, nextResetAt={}",
+                balance.getUser().getId(), expiresAt, nextResetAt);
     }
 }

--- a/src/main/java/com/proovy/domain/credit/service/CreditBalanceService.java
+++ b/src/main/java/com/proovy/domain/credit/service/CreditBalanceService.java
@@ -233,7 +233,7 @@ public class CreditBalanceService {
 
     private void refreshDailyCreditIfExpired(CreditBalance balance, LocalDateTime now) {
         LocalDateTime expiresAt = balance.getDailyExpiresAt();
-        if (expiresAt != null && expiresAt.isAfter(now)) {
+        if (expiresAt == null || expiresAt.isAfter(now)) {
             return;
         }
 

--- a/src/main/java/com/proovy/domain/credit/service/CreditHistoryService.java
+++ b/src/main/java/com/proovy/domain/credit/service/CreditHistoryService.java
@@ -20,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
@@ -39,6 +41,7 @@ public class CreditHistoryService {
     private static final int MIN_PAGE_SIZE = 1;
     private static final int MAX_PAGE_SIZE = 100;
     private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final ZoneId BILLING_ZONE = ZoneId.of("Asia/Seoul");
 
     @Transactional
     public CreditHistoryResponse getCreditHistory(
@@ -75,7 +78,7 @@ public class CreditHistoryService {
 
         // 6. 기간 통계 조회
         LocalDateTime summaryStartDate = startDate != null ? startDate : LocalDateTime.of(2020, 1, 1, 0, 0);
-        LocalDateTime summaryEndDate = endDate != null ? endDate : LocalDateTime.now().plusDays(1);
+        LocalDateTime summaryEndDate = endDate != null ? endDate : nowInBillingZone().plusDays(1);
 
         CreditHistoryRepository.CreditPeriodSummary periodSummary =
                 creditHistoryRepository.calculatePeriodSummary(
@@ -226,5 +229,9 @@ public class CreditHistoryService {
                 .history(historyDto)
                 .periodSummary(periodSummaryDto)
                 .build();
+    }
+
+    private LocalDateTime nowInBillingZone() {
+        return ZonedDateTime.now(BILLING_ZONE).toLocalDateTime();
     }
 }

--- a/src/main/java/com/proovy/domain/user/service/UserService.java
+++ b/src/main/java/com/proovy/domain/user/service/UserService.java
@@ -31,6 +31,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
@@ -41,6 +43,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserService {
+    private static final ZoneId BILLING_ZONE = ZoneId.of("Asia/Seoul");
 
     private final UserRepository userRepository;
     private final UserPlanRepository userPlanRepository;
@@ -102,7 +105,7 @@ public class UserService {
                 .limit(balance.getDailyFreeLimit())
                 .resetsAt(balance.getDailyExpiresAt() != null
                         ? balance.getDailyExpiresAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-                        : LocalDate.now().plusDays(1).atStartOfDay().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                        : LocalDate.now(BILLING_ZONE).plusDays(1).atStartOfDay().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
                 .build();
 
         // 월간 크레딧: 유료 플랜 구독 시 부여되는 크레딧
@@ -197,7 +200,7 @@ public class UserService {
         log.info("사용자 탈퇴 완료: userId={}", userId);
 
         return DeleteUserResponse.of(
-                LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                nowInBillingZone().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
         );
     }
 
@@ -236,5 +239,9 @@ public class UserService {
                 });
             }
         });
+    }
+
+    private LocalDateTime nowInBillingZone() {
+        return ZonedDateTime.now(BILLING_ZONE).toLocalDateTime();
     }
 }

--- a/src/main/java/com/proovy/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/proovy/global/config/JpaAuditingConfig.java
@@ -1,0 +1,19 @@
+package com.proovy.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+@Configuration
+public class JpaAuditingConfig {
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+    @Bean
+    public DateTimeProvider seoulDateTimeProvider() {
+        return () -> Optional.of(LocalDateTime.now(SEOUL_ZONE));
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,10 @@ spring:
 
   jpa:
     open-in-view: false
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: Asia/Seoul
 
   flyway:
     baseline-on-migrate: true
@@ -37,6 +41,7 @@ spring:
 
   task:
     scheduling:
+      time-zone: Asia/Seoul
       pool:
         size: 3
 

--- a/src/test/java/com/proovy/domain/credit/service/CreditBalanceServiceTest.java
+++ b/src/test/java/com/proovy/domain/credit/service/CreditBalanceServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.PlatformTransactionManager;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -37,6 +38,9 @@ class CreditBalanceServiceTest {
 
     @Mock
     private CreditHistoryRepository creditHistoryRepository;
+
+    @Mock
+    private PlatformTransactionManager transactionManager;
 
     @Test
     @DisplayName("같은 userPlanId로 월간 크레딧 재지급 요청 시 중복 지급하지 않는다")
@@ -91,5 +95,29 @@ class CreditBalanceServiceTest {
         ArgumentCaptor<CreditHistory> historyCaptor = ArgumentCaptor.forClass(CreditHistory.class);
         then(creditHistoryRepository).should().save(historyCaptor.capture());
         assertThat(historyCaptor.getValue().getAmount()).isEqualTo(5000);
+    }
+
+    @Test
+    @DisplayName("만료된 일일 크레딧은 조회 시 즉시 초기화된다")
+    void refreshExpiredDailyCreditWhenBalanceRequested() {
+        Long userId = 1L;
+        User user = User.builder().build();
+
+        CreditBalance balance = CreditBalance.builder()
+                .user(user)
+                .dailyFreeCredit(0)
+                .dailyFreeLimit(100)
+                .dailyExpiresAt(LocalDateTime.of(2026, 1, 1, 0, 0))
+                .freeCredit(0)
+                .paidCredit(0)
+                .build();
+
+        given(creditBalanceRepository.findByUserId(userId)).willReturn(Optional.of(balance));
+
+        CreditBalance result = creditBalanceService.getOrCreateBalance(userId);
+
+        assertThat(result.getDailyFreeCredit()).isEqualTo(100);
+        assertThat(result.getDailyExpiresAt()).isAfter(LocalDateTime.now());
+        then(creditBalanceRepository).should().save(balance);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #190 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- JPA Auditing createdAt을 Asia/Seoul 기준으로 고정
  - `@EnableJpaAuditing(dateTimeProviderRef="seoulDateTimeProvider")`
  - `JpaAuditingConfig`에서 `LocalDateTime.now(Asia/Seoul)` 제공
- 스케줄러 누락 대비: 일일 크레딧 “접근 시 만료 감지 → 즉시 리셋” 추가
  - `CreditBalanceService.getOrCreateBalance / forUpdate`에서 만료 체크 및 reset
- 크레딧 히스토리 집계 now()도 서울 시간으로 통일
- 프로필 응답 resetsAt fallback을 서울 시간으로 통일
- 설정 보강
  - `hibernate.jdbc.time_zone: Asia/Seoul`
  - `spring.task.scheduling.time-zone: Asia/Seoul`
- 테스트 추가
  - 만료된 일일 크레딧은 조회 시 즉시 초기화되는 케이스

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 만료된 일일 신용이 사용 시 즉시 자동으로 리셋됩니다.
  * 청구 기준 시간이 서울(Asia/Seoul) 타임존으로 통일되어 기간 계산과 리셋 시점이 일관화되었습니다.

* **Chores**
  * 감사(Auditing) 타임스탬프와 스케줄링이 서울 타임존 기준으로 적용됩니다.

* **Tests**
  * 만료된 일일 신용 리셋 동작을 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->