### PR TITLE
[Fix] 노트 제목 검색 시 중복 결과 제거 및 title-only 결과 단건화

### DIFF
--- a/src/main/java/com/proovy/domain/conversation/controller/ConversationController.java
+++ b/src/main/java/com/proovy/domain/conversation/controller/ConversationController.java
@@ -214,7 +214,11 @@ public class ConversationController {
     @GetMapping("/search")
     @Operation(
             summary = "대화 검색",
-            description = "사용자의 모든 노트에서 대화를 검색합니다. PostgreSQL Full-Text Search를 활용합니다."
+            description = """
+                    사용자의 모든 노트에서 대화를 검색합니다. PostgreSQL Full-Text Search를 활용합니다.
+                    
+                    노트 제목만 매칭된 결과는 conversationId/userMessage/assistantMessage가 null일 수 있습니다.
+                    """
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/proovy/domain/conversation/dto/response/ConversationSearchResponse.java
+++ b/src/main/java/com/proovy/domain/conversation/dto/response/ConversationSearchResponse.java
@@ -1,5 +1,6 @@
 package com.proovy.domain.conversation.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +10,7 @@ import java.util.List;
 
 @Getter
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "대화 검색 결과 응답")
 public class ConversationSearchResponse {
 
@@ -18,18 +20,22 @@ public class ConversationSearchResponse {
 
     @Getter
     @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class ConversationSearchItem {
-        @Schema(description = "대화 ID (ChatMessage ID)", example = "150")
+        @Schema(description = "대화 ID (ChatMessage ID). 제목만 매칭된 결과에서는 null", example = "150", nullable = true)
         private Long conversationId;
         
         @Schema(description = "노트 ID", example = "10")
         private Long noteId;
         private String noteTitle;
+        @Schema(description = "사용자 메시지 매칭 정보. 제목만 매칭된 결과에서는 null", nullable = true)
         private MessageInfo userMessage;
+        @Schema(description = "어시스턴트 메시지 매칭 정보. 제목만 매칭된 결과에서는 null", nullable = true)
         private MessageInfo assistantMessage;
         private List<MentionedFile> mentionedFiles;
         private List<String> mentionedTools;
         private Double relevance;
+        @Schema(description = "결과 기준 시각. 제목만 매칭된 결과에서는 노트 생성 시각", nullable = true)
         private LocalDateTime createdAt;
     }
 

--- a/src/main/java/com/proovy/domain/conversation/service/ConversationQueryServiceImpl.java
+++ b/src/main/java/com/proovy/domain/conversation/service/ConversationQueryServiceImpl.java
@@ -253,13 +253,13 @@ public class ConversationQueryServiceImpl implements ConversationQueryService {
 
             ConversationSearchResponse.ConversationSearchItem.ConversationSearchItemBuilder builder =
                     ConversationSearchResponse.ConversationSearchItem.builder()
-                            .conversationId(message.getId())
+                            .conversationId(contentMatches ? message.getId() : null)
                             .noteId(note.getId())
                             .noteTitle(note.getTitle())
                             .mentionedFiles(Collections.emptyList())
                             .mentionedTools(Collections.emptyList())
                             .relevance(contentMatches ? calculateRelevance(textContent, query) : 0.3)
-                            .createdAt(message.getCreatedAt());
+                            .createdAt(contentMatches ? message.getCreatedAt() : note.getCreatedAt());
 
             if (contentMatches) {
                 if (message.getRole() == MessageRole.USER) {

--- a/src/main/java/com/proovy/domain/conversation/service/ConversationQueryServiceImpl.java
+++ b/src/main/java/com/proovy/domain/conversation/service/ConversationQueryServiceImpl.java
@@ -209,6 +209,7 @@ public class ConversationQueryServiceImpl implements ConversationQueryService {
 
     /**
      * ChatMessage 검색 결과를 ConversationSearchItem 목록으로 변환
+     * 노트 제목만 매칭된 경우(메시지 내용에 검색어 없음) 노트당 하나만 반환
      */
     private List<ConversationSearchResponse.ConversationSearchItem> buildSearchItemsFromChatMessages(
             List<ChatMessage> messages,
@@ -218,47 +219,54 @@ public class ConversationQueryServiceImpl implements ConversationQueryService {
             return Collections.emptyList();
         }
 
+        String lowerQuery = query.toLowerCase();
         List<ConversationSearchResponse.ConversationSearchItem> results = new ArrayList<>();
+        Set<Long> titleOnlyNoteIds = new HashSet<>();
 
         for (ChatMessage message : messages) {
             Note note = message.getNote();
             if (note == null) {
-                continue; // Note가 없는 메시지는 검색 결과에서 제외
+                continue;
             }
 
             String textContent = message.getTextContent();
-            if (textContent == null || textContent.isBlank()) {
-                continue; // 텍스트가 없는 메시지는 검색 결과에서 제외
+            boolean contentMatches = textContent != null && !textContent.isBlank()
+                    && textContent.toLowerCase().contains(lowerQuery);
+            boolean titleMatches = note.getTitle() != null
+                    && note.getTitle().toLowerCase().contains(lowerQuery);
+
+            // 노트 제목만 매칭(내용에는 검색어 없음)인 경우 노트당 하나만 반환
+            if (!contentMatches && titleMatches) {
+                if (titleOnlyNoteIds.contains(note.getId())) {
+                    continue;
+                }
+                titleOnlyNoteIds.add(note.getId());
             }
 
-            ConversationSearchResponse.MessageInfo messageInfo =
-                    buildMessageInfoFromChatMessage(message, query);
+            if (!contentMatches && !titleMatches) {
+                continue;
+            }
 
-            // 빈 MessageInfo (null 방지)
-            ConversationSearchResponse.MessageInfo emptyMessageInfo =
-                    ConversationSearchResponse.MessageInfo.builder()
-                            .text("")
-                            .preview("")
-                            .highlight("")
-                            .build();
+            ConversationSearchResponse.MessageInfo messageInfo = contentMatches
+                    ? buildMessageInfoFromChatMessage(message, query)
+                    : null;
 
-            // 메시지 역할에 따라 userMessage 또는 assistantMessage 설정
             ConversationSearchResponse.ConversationSearchItem.ConversationSearchItemBuilder builder =
                     ConversationSearchResponse.ConversationSearchItem.builder()
-                            .conversationId(message.getId()) // ChatMessage ID를 conversationId로 사용
+                            .conversationId(message.getId())
                             .noteId(note.getId())
                             .noteTitle(note.getTitle())
                             .mentionedFiles(Collections.emptyList())
                             .mentionedTools(Collections.emptyList())
-                            .relevance(calculateRelevance(textContent, query))
+                            .relevance(contentMatches ? calculateRelevance(textContent, query) : 0.3)
                             .createdAt(message.getCreatedAt());
 
-            if (message.getRole() == MessageRole.USER) {
-                builder.userMessage(messageInfo);
-                builder.assistantMessage(emptyMessageInfo);
-            } else if (message.getRole() == MessageRole.ASSISTANT) {
-                builder.userMessage(emptyMessageInfo);
-                builder.assistantMessage(messageInfo);
+            if (contentMatches) {
+                if (message.getRole() == MessageRole.USER) {
+                    builder.userMessage(messageInfo);
+                } else if (message.getRole() == MessageRole.ASSISTANT) {
+                    builder.assistantMessage(messageInfo);
+                }
             }
 
             results.add(builder.build());


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #192 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 대화 검색 결과 생성 로직에서 제목 매칭/내용 매칭을 분리
- 노트 제목만 매칭되고 메시지 내용에는 검색어가 없는 경우:
  - noteId 기준으로 dedupe하여 **노트당 1개 결과만** 반환
- 메시지 내용 매칭은 기존처럼 메시지 단위 반환 유지
- title-only 결과는 relevance 기본값 부여(예: 0.3)

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 검색 기능 개선 사항

**새로운 기능**
- 대소문자를 구분하지 않는 검색 기능 추가
- 메시지 콘텐츠와 제목을 모두 기반으로 하는 통합 검색 기능

**버그 수정**
- 제목 기반 검색 시 중복 결과 제거
- 검색 결과의 관련성 점수 계산 로직 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->