### PR TITLE
[Fix] 새 노트 기본 제목 생성 시간을 서울 기준으로 고정

### DIFF
--- a/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
+++ b/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
@@ -33,6 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.proovy.global.infra.s3.S3Service;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -114,7 +115,7 @@ public class NoteServiceImpl implements NoteService {
             return normalized;
         }
 
-        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+        String timestamp = LocalDateTime.now(ZoneId.of("Asia/Seoul")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
         return "새 노트 " + timestamp;
     }
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #194 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 새 노트 기본 제목 생성 시각을 서버 기본 시간대가 아닌 Asia/Seoul 기준으로 고정
  - `LocalDateTime.now()` → `LocalDateTime.now(ZoneId.of("Asia/Seoul"))`
- `ZoneId` import 추가

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 서버 배포 지역/기본 타임존 설정과 무관하게 노트 제목 시간이 KST로 일관되게 생성됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 노트의 자동 생성 제목에 포함되는 타임스탬프가 한국 시간대(서울)로 설정되도록 개선되었습니다. 이제 시간 정보가 사용자의 로컬 시간대를 올바르게 반영합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->