### PR TITLE
[Feat] AI 노트 제목 생성 API 엔드포인트 추가

### DIFF
--- a/src/main/java/com/proovy/domain/note/controller/NoteController.java
+++ b/src/main/java/com/proovy/domain/note/controller/NoteController.java
@@ -1,6 +1,7 @@
 package com.proovy.domain.note.controller;
 
 import com.proovy.domain.note.dto.request.CreateNoteRequest;
+import com.proovy.domain.note.dto.request.GenerateTitleRequest;
 import com.proovy.domain.note.dto.request.UpdateNoteTitleRequest;
 import com.proovy.domain.note.dto.response.CreateNoteResponse;
 import com.proovy.domain.note.dto.response.DeleteNoteResponse;
@@ -315,6 +316,50 @@ public class NoteController {
         List<Tool> tools = toolService.getToolList(query);
         ToolListResponse response = ToolListResponse.from(tools);
         return ApiResponse.success("도구 목록 조회에 성공했습니다.", response);
+    }
+
+    @PostMapping("/{noteId}/generate-title")
+    @Operation(
+            summary = "첫 질문 기반 노트 제목 AI 생성",
+            description = """
+                    사용자의 첫 질문 내용을 Gemini로 분석하여 노트 제목을 자동 생성하고 업데이트합니다.
+
+                    - 노트 생성 직후, 첫 대화 전송과 병렬로 호출합니다.
+                    - 생성된 제목은 30자 이내입니다.
+                    - 생성 실패 시 기존 날짜/시간 제목이 유지됩니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "제목 생성 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "노트 접근 권한 없음 (NOTE4031)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "노트 없음 (NOTE4041)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "AI 제목 생성 실패 (NOTE5001)"
+            )
+    })
+    public ApiResponse<UpdateNoteTitleResponse> generateNoteTitle(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Parameter(description = "제목을 생성할 노트의 고유 ID", example = "10")
+            @PathVariable Long noteId,
+            @Valid @RequestBody GenerateTitleRequest request
+    ) {
+        log.info("AI 노트 제목 생성 요청 - userId: {}, noteId: {}", userPrincipal.getUserId(), noteId);
+        UpdateNoteTitleResponse response = noteService.generateNoteTitle(
+                userPrincipal.getUserId(),
+                noteId,
+                request
+        );
+        return ApiResponse.success("노트 제목이 생성되었습니다.", response);
     }
 
     @GetMapping("/{noteId}/assets")

--- a/src/main/java/com/proovy/domain/note/dto/request/GenerateTitleRequest.java
+++ b/src/main/java/com/proovy/domain/note/dto/request/GenerateTitleRequest.java
@@ -1,0 +1,11 @@
+package com.proovy.domain.note.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record GenerateTitleRequest(
+        @NotBlank(message = "질문 내용을 입력해주세요.")
+        @Size(max = 2000, message = "질문 내용은 2000자 이내로 입력해주세요.")
+        String text
+) {
+}

--- a/src/main/java/com/proovy/domain/note/dto/request/UpdateNoteTitleRequest.java
+++ b/src/main/java/com/proovy/domain/note/dto/request/UpdateNoteTitleRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Size;
 
 public record UpdateNoteTitleRequest(
         @NotBlank(message = "노트 제목을 입력해주세요.")
-        @Size(max = 50, message = "노트 제목은 50자 이내로 입력해주세요.")
+        @Size(max = 30, message = "노트 제목은 30자 이내로 입력해주세요.")
         String title
 ) {
 }

--- a/src/main/java/com/proovy/domain/note/service/NoteService.java
+++ b/src/main/java/com/proovy/domain/note/service/NoteService.java
@@ -1,6 +1,7 @@
 package com.proovy.domain.note.service;
 
 import com.proovy.domain.note.dto.request.CreateNoteRequest;
+import com.proovy.domain.note.dto.request.GenerateTitleRequest;
 import com.proovy.domain.note.dto.request.UpdateNoteTitleRequest;
 import com.proovy.domain.note.dto.response.CreateNoteResponse;
 import com.proovy.domain.note.dto.response.DeleteNoteResponse;
@@ -15,6 +16,8 @@ public interface NoteService {
     NoteListResponse getNoteList(Long userId, int page, int size, String sort);
 
     UpdateNoteTitleResponse updateNoteTitle(Long userId, Long noteId, UpdateNoteTitleRequest request);
+
+    UpdateNoteTitleResponse generateNoteTitle(Long userId, Long noteId, GenerateTitleRequest request);
 
     DeleteNoteResponse deleteNote(Long userId, Long noteId);
 

--- a/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
+++ b/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
@@ -6,14 +6,15 @@ import com.proovy.domain.asset.repository.AssetRepository;
 import com.proovy.domain.conversation.entity.*;
 import com.proovy.domain.conversation.repository.*;
 import com.proovy.domain.note.dto.request.CreateNoteRequest;
+import com.proovy.domain.note.dto.request.GenerateTitleRequest;
 import com.proovy.domain.note.dto.request.UpdateNoteTitleRequest;
 import com.proovy.domain.note.dto.response.CreateNoteResponse;
 import com.proovy.domain.note.dto.response.DeleteNoteResponse;
 import com.proovy.domain.note.dto.response.NoteDetailResponse;
-import com.proovy.domain.note.dto.response.DeleteNoteResponse;
 import com.proovy.domain.note.dto.response.NoteListResponse;
 import com.proovy.domain.note.dto.response.UpdateNoteTitleResponse;
 import com.proovy.domain.note.dto.response.AssetListResponse;
+import com.proovy.global.infra.gemini.GeminiClient;
 import com.proovy.domain.note.entity.Note;
 import com.proovy.domain.note.repository.NoteRepository;
 import com.proovy.domain.embedding.service.EmbeddingJobPublisher;
@@ -53,6 +54,7 @@ public class NoteServiceImpl implements NoteService {
     private final com.proovy.domain.user.repository.UserPlanRepository userPlanRepository;
     private final S3Service s3Service;
     private final EmbeddingJobPublisher embeddingJobPublisher;
+    private final GeminiClient geminiClient;
 
     @Override
     public CreateNoteResponse createNote(Long userId, CreateNoteRequest request) {
@@ -284,6 +286,40 @@ public class NoteServiceImpl implements NoteService {
         log.info("노트 제목 수정 완료 - noteId: {}", noteId);
 
         // 4. Response 생성
+        return UpdateNoteTitleResponse.builder()
+                .noteId(note.getId())
+                .title(note.getTitle())
+                .updatedAt(note.getUpdatedAt())
+                .build();
+    }
+
+    @Override
+    public UpdateNoteTitleResponse generateNoteTitle(Long userId, Long noteId, GenerateTitleRequest request) {
+        log.info("AI 노트 제목 생성 요청 - userId: {}, noteId: {}", userId, noteId);
+
+        // 1. 노트 조회 및 권한 확인
+        Note note = noteRepository.findById(noteId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTE4041));
+
+        if (!note.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.NOTE4031);
+        }
+
+        // 2. Gemini로 제목 생성
+        String generatedTitle;
+        try {
+            generatedTitle = geminiClient.generateNoteTitle(request.text());
+        } catch (Exception e) {
+            log.warn("Gemini 제목 생성 실패 - noteId: {}, error: {}", noteId, e.getMessage());
+            throw new BusinessException(ErrorCode.NOTE5001);
+        }
+
+        // 3. 제목 업데이트
+        note.updateTitle(generatedTitle);
+        note = noteRepository.save(note);
+
+        log.info("AI 노트 제목 생성 완료 - noteId: {}, title: {}", noteId, generatedTitle);
+
         return UpdateNoteTitleResponse.builder()
                 .noteId(note.getId())
                 .title(note.getTitle())

--- a/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
+++ b/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
@@ -305,16 +305,30 @@ public class NoteServiceImpl implements NoteService {
             throw new BusinessException(ErrorCode.NOTE4031);
         }
 
-        // 2. Gemini로 제목 생성
+        // 2. Gemini로 제목 생성 (실패 시 기존 제목 유지)
         String generatedTitle;
         try {
             generatedTitle = geminiClient.generateNoteTitle(request.text());
         } catch (Exception e) {
-            log.warn("Gemini 제목 생성 실패 - noteId: {}, error: {}", noteId, e.getMessage());
-            throw new BusinessException(ErrorCode.NOTE5001);
+            log.warn("Gemini 제목 생성 실패 - noteId: {}, 기존 제목 유지, error: {}", noteId, e.getMessage());
+            return UpdateNoteTitleResponse.builder()
+                    .noteId(note.getId())
+                    .title(note.getTitle())
+                    .updatedAt(note.getUpdatedAt())
+                    .build();
         }
 
-        // 3. 제목 업데이트
+        // 3. 빈 제목 방어 (비어있으면 기존 제목 유지)
+        if (generatedTitle == null || generatedTitle.isBlank()) {
+            log.warn("Gemini 제목 생성 결과가 비어있음 - noteId: {}, 기존 제목 유지", noteId);
+            return UpdateNoteTitleResponse.builder()
+                    .noteId(note.getId())
+                    .title(note.getTitle())
+                    .updatedAt(note.getUpdatedAt())
+                    .build();
+        }
+
+        // 4. 제목 업데이트
         note.updateTitle(generatedTitle);
         note = noteRepository.save(note);
 

--- a/src/main/java/com/proovy/global/infra/gemini/GeminiClient.java
+++ b/src/main/java/com/proovy/global/infra/gemini/GeminiClient.java
@@ -10,6 +10,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -71,20 +72,24 @@ public class GeminiClient {
                 .bodyValue(requestBody)
                 .retrieve()
                 .bodyToMono(OpenRouterResponse.class)
-                .block();
+                .block(Duration.ofSeconds(10));
 
-        if (response == null
-                || response.choices() == null
-                || response.choices().isEmpty()
-                || response.choices().get(0).message() == null) {
+        String content = (response != null
+                && response.choices() != null
+                && !response.choices().isEmpty()
+                && response.choices().get(0).message() != null)
+                ? response.choices().get(0).message().content()
+                : null;
+
+        if (content == null || content.isBlank()) {
             throw new RuntimeException("OpenRouter API 응답이 비어있습니다.");
         }
 
-        String title = response.choices().get(0).message().content().trim();
+        String title = content.trim();
 
-        // 30자 초과 시 자르기
+        // 30자 초과 시 말줄임표 처리
         if (title.length() > 30) {
-            title = title.substring(0, 30);
+            title = title.substring(0, 27) + "...";
         }
 
         log.debug("OpenRouter 제목 생성 완료: {}", title);

--- a/src/main/java/com/proovy/global/infra/gemini/GeminiClient.java
+++ b/src/main/java/com/proovy/global/infra/gemini/GeminiClient.java
@@ -37,7 +37,7 @@ public class GeminiClient {
             - 질문의 핵심 주제를 간결하게 표현
             - 제목만 출력 (설명, 따옴표, 줄바꿈 없이)
 
-            질문: %s
+            질문: {{QUESTION}}
             """;
 
     /**
@@ -52,7 +52,7 @@ public class GeminiClient {
                 ? questionText.substring(0, 500)
                 : questionText;
 
-        String prompt = String.format(TITLE_PROMPT_TEMPLATE, truncatedText);
+        String prompt = TITLE_PROMPT_TEMPLATE.replace("{{QUESTION}}", truncatedText);
 
         Map<String, Object> requestBody = Map.of(
                 "model", model,

--- a/src/main/java/com/proovy/global/infra/gemini/GeminiClient.java
+++ b/src/main/java/com/proovy/global/infra/gemini/GeminiClient.java
@@ -1,0 +1,106 @@
+package com.proovy.global.infra.gemini;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GeminiClient {
+
+    private final WebClient webClient;
+
+    @Value("${openrouter.api.key}")
+    private String apiKey;
+
+    @Value("${openrouter.api.model:google/gemini-2.5-flash-lite-preview-09-2025}")
+    private String model;
+
+    private static final String OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+
+    private static final String TITLE_PROMPT_TEMPLATE = """
+            다음 사용자 질문을 읽고, 노트 제목을 30자 이내로 만들어주세요.
+
+            규칙:
+            - 30자 이내
+            - 질문의 핵심 주제를 간결하게 표현
+            - 제목만 출력 (설명, 따옴표, 줄바꿈 없이)
+
+            질문: %s
+            """;
+
+    /**
+     * 사용자 질문을 기반으로 노트 제목을 생성합니다. (OpenRouter 경유)
+     *
+     * @param questionText 사용자의 첫 질문 텍스트
+     * @return 생성된 노트 제목 (30자 이내)
+     */
+    public String generateNoteTitle(String questionText) {
+        // 질문이 너무 길면 앞부분만 사용 (토큰 절약)
+        String truncatedText = questionText.length() > 500
+                ? questionText.substring(0, 500)
+                : questionText;
+
+        String prompt = String.format(TITLE_PROMPT_TEMPLATE, truncatedText);
+
+        Map<String, Object> requestBody = Map.of(
+                "model", model,
+                "messages", List.of(
+                        Map.of("role", "user", "content", prompt)
+                ),
+                "max_tokens", 60,
+                "temperature", 0.2
+        );
+
+        log.debug("OpenRouter 제목 생성 요청 - model: {}", model);
+
+        OpenRouterResponse response = webClient.post()
+                .uri(OPENROUTER_URL)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(OpenRouterResponse.class)
+                .block();
+
+        if (response == null
+                || response.choices() == null
+                || response.choices().isEmpty()
+                || response.choices().get(0).message() == null) {
+            throw new RuntimeException("OpenRouter API 응답이 비어있습니다.");
+        }
+
+        String title = response.choices().get(0).message().content().trim();
+
+        // 30자 초과 시 자르기
+        if (title.length() > 30) {
+            title = title.substring(0, 30);
+        }
+
+        log.debug("OpenRouter 제목 생성 완료: {}", title);
+        return title;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OpenRouterResponse(List<Choice> choices) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Choice(Message message) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Message(
+            String role,
+            String content,
+            @JsonProperty("refusal") String refusal
+    ) {}
+}

--- a/src/main/java/com/proovy/global/response/ErrorCode.java
+++ b/src/main/java/com/proovy/global/response/ErrorCode.java
@@ -73,6 +73,7 @@ public enum ErrorCode {
     NOTE4002("NOTE4002", "노트 제목을 입력해주세요.", HttpStatus.BAD_REQUEST),
     NOTE4041("NOTE4041", "노트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     NOTE4031("NOTE4031", "노트 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    NOTE5001("NOTE5001", "AI 노트 제목 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // Credit
     CREDIT4001("CREDIT4001", "날짜 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/proovy/global/response/ErrorCode.java
+++ b/src/main/java/com/proovy/global/response/ErrorCode.java
@@ -69,7 +69,7 @@ public enum ErrorCode {
     CONV5001("CONV5001", "Proovy-ai 통신 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     CONV5002("CONV5002", "Proovy-ai 스트리밍 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     // Note
-    NOTE4001("NOTE4001", "노트 제목은 50자 이내로 입력해주세요.", HttpStatus.BAD_REQUEST),
+    NOTE4001("NOTE4001", "노트 제목은 30자 이내로 입력해주세요.", HttpStatus.BAD_REQUEST),
     NOTE4002("NOTE4002", "노트 제목을 입력해주세요.", HttpStatus.BAD_REQUEST),
     NOTE4041("NOTE4041", "노트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     NOTE4031("NOTE4031", "노트 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -139,6 +139,14 @@ embedding:
       prefix: emb:lock
       ttl: 3600
 
+# ===============================
+# OpenRouter API (Gemini 2.5 Flash 경유)
+# ===============================
+openrouter:
+  api:
+    key: ${OPENROUTER_API_KEY}
+    model: google/gemini-2.5-flash-lite-preview-09-2025
+
 ---
 # ===============================
 # Local 환경


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #196 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- AI 기반 노트 제목 생성 API 추가 (`POST /api/notes/{noteId}/generate-title`)
- `GenerateTitleRequest` DTO 추가
- `GeminiClient`를 사용하여 제목 생성 요청
- 제목 생성 후 노트 제목 업데이트
- 제목 생성 실패 시 기존 제목 유지

## 📸 스크린샷

<img width="968" height="799" alt="스크린샷 2026-02-19 011410" src="https://github.com/user-attachments/assets/dcb613e8-f0f3-433f-bc50-36f92a593c19" />

<img width="967" height="342" alt="스크린샷 2026-02-19 011423" src="https://github.com/user-attachments/assets/10e57ecf-e197-4cd7-b2cd-37aec493d1cd" />


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- Gemini API를 통해 AI 제목을 생성합니다. 실패 시 기존 제목을 유지하므로 안정성을 확보할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * AI가 사용자의 질문을 분석해 노트 제목을 자동으로 생성해 노트에 즉시 반영하는 기능이 추가되었습니다.
* **변경**
  * 노트 제목 허용 길이가 기존보다 짧아져 최대 30자로 제한됩니다.
* **오류 처리**
  * AI 생성 실패 시 관련 오류 응답이 추가되어 문제 발생 시 안내가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->