### PR TITLE
[Refactor] S3 잔재 완전 제거 및 GCS 정합성 맞추기

### DIFF
--- a/src/main/java/com/proovy/domain/asset/dto/response/UploadConfirmResponse.java
+++ b/src/main/java/com/proovy/domain/asset/dto/response/UploadConfirmResponse.java
@@ -44,7 +44,7 @@ public class UploadConfirmResponse {
                 .mimeType(asset.getMimeType())
                 .source(asset.getSource().name())
                 .ocrStatus(asset.getOcrStatus() != null ? asset.getOcrStatus().name() : null)
-                .thumbnailS3Key(asset.getThumbnailS3Key())
+                .thumbnailS3Key(asset.getThumbnailObjectKey())
                 .createdAt(asset.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/proovy/domain/asset/entity/Asset.java
+++ b/src/main/java/com/proovy/domain/asset/entity/Asset.java
@@ -37,11 +37,11 @@ public class Asset {
     @Column(nullable = false, length = 100)
     private String mimeType;
 
-    @Column(nullable = false, length = 500)
-    private String s3Key; // S3 저장 경로
+    @Column(name = "object_key", nullable = false, length = 500)
+    private String objectKey; // GCS 저장 경로
 
-    @Column(length = 500)
-    private String thumbnailS3Key; // 썸네일 S3 경로
+    @Column(name = "thumbnail_object_key", length = 500)
+    private String thumbnailObjectKey; // 썸네일 GCS 경로
 
     @Column(nullable = false, length = 20)
     @Enumerated(EnumType.STRING)
@@ -77,15 +77,15 @@ public class Asset {
 
     @Builder
     public Asset(Long userId, Long noteId, String fileName, Long fileSize,
-                 String mimeType, String s3Key, String thumbnailS3Key, AssetSource source,
+                 String mimeType, String objectKey, String thumbnailObjectKey, AssetSource source,
                  AssetStatus status, LocalDateTime uploadExpiresAt) {
         this.userId = userId;
         this.noteId = noteId;
         this.fileName = fileName;
         this.fileSize = fileSize;
         this.mimeType = mimeType;
-        this.s3Key = s3Key;
-        this.thumbnailS3Key = thumbnailS3Key;
+        this.objectKey = objectKey;
+        this.thumbnailObjectKey = thumbnailObjectKey;
         this.source = source;
         this.status = status;
         this.uploadExpiresAt = uploadExpiresAt;
@@ -129,10 +129,10 @@ public class Asset {
     }
 
     /**
-     * 썸네일 S3 키 업데이트
+     * 썸네일 Object 키 업데이트
      */
-    public void updateThumbnail(String thumbnailS3Key) {
-        this.thumbnailS3Key = thumbnailS3Key;
+    public void updateThumbnail(String thumbnailObjectKey) {
+        this.thumbnailObjectKey = thumbnailObjectKey;
         // 이미지 파일은 썸네일만 있으면 완료 (OCR 불필요)
         if (this.ocrStatus == OcrStatus.processing) {
             this.ocrStatus = OcrStatus.completed;

--- a/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
+++ b/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
@@ -94,7 +94,7 @@ public class AssetsServiceImpl implements AssetsService {
                 .fileName(request.getFileName())
                 .fileSize(request.getFileSize())
                 .mimeType(request.getMimeType())
-                .s3Key(s3Key)
+                .objectKey(s3Key)
                 .source(Asset.AssetSource.upload)
                 .status(AssetStatus.PENDING)
                 .uploadExpiresAt(expiresAt)
@@ -172,7 +172,7 @@ public class AssetsServiceImpl implements AssetsService {
         // 3. Presigned URL 생성
         LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(PRESIGNED_URL_DURATION_MINUTES);
         String downloadUrl = s3Service.generatePresignedDownloadUrl(
-                asset.getS3Key(),
+                asset.getObjectKey(),
                 asset.getFileName(),
                 PRESIGNED_URL_DURATION_MINUTES
         );
@@ -200,7 +200,7 @@ public class AssetsServiceImpl implements AssetsService {
         }
 
         // 4. S3 파일 존재 여부 확인
-        if (!s3Service.doesFileExist(asset.getS3Key())) {
+        if (!s3Service.doesFileExist(asset.getObjectKey())) {
             throw new BusinessException(ErrorCode.ASSET4007);
         }
 
@@ -217,7 +217,7 @@ public class AssetsServiceImpl implements AssetsService {
 
         // 6. 썸네일 생성
         final Long savedAssetId = asset.getId();
-        final String s3Key = asset.getS3Key();
+        final String s3Key = asset.getObjectKey();
         final String mimeType = asset.getMimeType();
 
         // 이미지 파일인 경우: 동기적으로 썸네일 생성 (빠른 응답)
@@ -252,8 +252,8 @@ public class AssetsServiceImpl implements AssetsService {
                 assetId, userId, asset.getOcrStatus());
 
         // 썸네일 URL 생성 (있는 경우)
-        String thumbnailUrl = asset.getThumbnailS3Key() != null
-                ? s3Service.getThumbnailUrl(asset.getThumbnailS3Key())
+        String thumbnailUrl = asset.getThumbnailObjectKey() != null
+                ? s3Service.getThumbnailUrl(asset.getThumbnailObjectKey())
                 : null;
 
         return AssetDetailResponse.from(asset, thumbnailUrl);
@@ -273,8 +273,8 @@ public class AssetsServiceImpl implements AssetsService {
         log.debug("[Asset] 자산 상세 조회 - assetId: {}, ocrStatus: {}", assetId, asset.getOcrStatus());
 
         // 썸네일 URL 생성 (있는 경우)
-        String thumbnailUrl = asset.getThumbnailS3Key() != null
-                ? s3Service.getThumbnailUrl(asset.getThumbnailS3Key())
+        String thumbnailUrl = asset.getThumbnailObjectKey() != null
+                ? s3Service.getThumbnailUrl(asset.getThumbnailObjectKey())
                 : null;
 
         return AssetDetailResponse.from(asset, thumbnailUrl);
@@ -293,8 +293,8 @@ public class AssetsServiceImpl implements AssetsService {
         }
 
         // S3 키 저장 (트랜잭션 커밋 후 삭제를 위해)
-        final String s3Key = asset.getS3Key();
-        final String thumbnailS3Key = asset.getThumbnailS3Key();
+        final String s3Key = asset.getObjectKey();
+        final String thumbnailS3Key = asset.getThumbnailObjectKey();
 
         // 3. DB Asset 레코드 삭제 (먼저 수행)
         assetRepository.delete(asset);

--- a/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
+++ b/src/main/java/com/proovy/domain/asset/service/AssetsServiceImpl.java
@@ -292,32 +292,32 @@ public class AssetsServiceImpl implements AssetsService {
             throw new BusinessException(ErrorCode.ASSET4031);
         }
 
-        // S3 키 저장 (트랜잭션 커밋 후 삭제를 위해)
-        final String s3Key = asset.getObjectKey();
-        final String thumbnailS3Key = asset.getThumbnailObjectKey();
+        // GCS 키 저장 (트랜잭션 커밋 후 삭제를 위해)
+        final String objectKey = asset.getObjectKey();
+        final String thumbnailObjectKey = asset.getThumbnailObjectKey();
 
         // 3. DB Asset 레코드 삭제 (먼저 수행)
         assetRepository.delete(asset);
 
-        // 4. 트랜잭션 커밋 후 S3 파일 삭제 (afterCommit 콜백)
+        // 4. 트랜잭션 커밋 후 GCS 파일 삭제 (afterCommit 콜백)
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                // S3 원본 파일 삭제
+                // GCS 원본 파일 삭제
                 try {
-                    s3Service.deleteFile(s3Key);
-                    log.info("[Asset] S3 원본 파일 삭제 완료 - s3Key: {}", s3Key);
+                    s3Service.deleteFile(objectKey);
+                    log.info("[Asset] GCS 원본 파일 삭제 완료 - objectKey: {}", objectKey);
                 } catch (Exception e) {
-                    log.error("[Asset] S3 원본 파일 삭제 실패 - s3Key: {}, error: {}", s3Key, e.getMessage());
+                    log.error("[Asset] GCS 원본 파일 삭제 실패 - objectKey: {}, error: {}", objectKey, e.getMessage());
                 }
 
-                // S3 썸네일 삭제 (있는 경우)
-                if (thumbnailS3Key != null && !thumbnailS3Key.equals(s3Key)) {
+                // GCS 썸네일 삭제 (원본과 다른 경우에만)
+                if (thumbnailObjectKey != null && !thumbnailObjectKey.equals(objectKey)) {
                     try {
-                        s3Service.deleteFile(thumbnailS3Key);
-                        log.info("[Asset] S3 썸네일 삭제 완료 - s3Key: {}", thumbnailS3Key);
+                        s3Service.deleteFile(thumbnailObjectKey);
+                        log.info("[Asset] GCS 썸네일 삭제 완료 - thumbnailObjectKey: {}", thumbnailObjectKey);
                     } catch (Exception e) {
-                        log.error("[Asset] S3 썸네일 삭제 실패 - s3Key: {}, error: {}", thumbnailS3Key, e.getMessage());
+                        log.error("[Asset] GCS 썸네일 삭제 실패 - thumbnailObjectKey: {}, error: {}", thumbnailObjectKey, e.getMessage());
                     }
                 }
             }

--- a/src/main/java/com/proovy/domain/conversation/dto/response/CanvasImageUploadResponse.java
+++ b/src/main/java/com/proovy/domain/conversation/dto/response/CanvasImageUploadResponse.java
@@ -26,7 +26,7 @@ public class CanvasImageUploadResponse {
                 .fileName(asset.getFileName())
                 .fileSize(asset.getFileSize())
                 .mimeType(asset.getMimeType())
-                .storageKey(asset.getS3Key())
+                .storageKey(asset.getObjectKey())
                 .uploadUrl(uploadUrl)
                 .createdAt(asset.getCreatedAt())
                 .build();

--- a/src/main/java/com/proovy/domain/conversation/service/ChatServiceImpl.java
+++ b/src/main/java/com/proovy/domain/conversation/service/ChatServiceImpl.java
@@ -506,9 +506,9 @@ public class ChatServiceImpl implements ChatService {
                 .map(asset -> {
                     // Presigned URL 생성 (15분 유효)
                     String url = s3Service.generatePresignedDownloadUrl(
-                            asset.getS3Key(), asset.getFileName(), 15);
-                    log.debug("[Chat] Presigned URL 생성 - assetId: {}, s3Key: {}",
-                            asset.getId(), asset.getS3Key());
+                            asset.getObjectKey(), asset.getFileName(), 15);
+                    log.debug("[Chat] Presigned URL 생성 - assetId: {}, objectKey: {}",
+                            asset.getId(), asset.getObjectKey());
                     return url;
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/com/proovy/domain/conversation/service/ConversationQueryServiceImpl.java
+++ b/src/main/java/com/proovy/domain/conversation/service/ConversationQueryServiceImpl.java
@@ -69,7 +69,7 @@ public class ConversationQueryServiceImpl implements ConversationQueryService {
                 .fileName(request.getFileName())
                 .fileSize(request.getFileSize())
                 .mimeType(request.getMimeType())
-                .s3Key(s3Key)
+                .objectKey(s3Key)
                 .source(Asset.AssetSource.upload)
                 .status(AssetStatus.PENDING)
                 .uploadExpiresAt(expiresAt)

--- a/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
+++ b/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
@@ -357,20 +357,20 @@ public class NoteServiceImpl implements NoteService {
         long messageCount = chatMessageRepository.countByNoteId(noteId);
         long conversationCount = messageCount / 2;
 
-        // 3. S3 삭제를 위한 Asset 정보만 조회 (영속성 컨텍스트 오염 방지를 위해 별도 처리)
+        // 3. GCS 삭제를 위한 Asset 정보만 조회 (영속성 컨텍스트 오염 방지를 위해 별도 처리)
         List<Asset> assets = assetRepository.findAllByNoteId(noteId);
         int assetCount = assets.size();
 
-        List<String> s3KeysToDelete = new ArrayList<>();
+        Set<String> objectKeysToDelete = new HashSet<>();
         long freedStorageBytes = 0L;
 
         for (Asset asset : assets) {
             if (asset.getObjectKey() != null) {
-                s3KeysToDelete.add(asset.getObjectKey());
+                objectKeysToDelete.add(asset.getObjectKey());
                 freedStorageBytes += asset.getFileSize();
             }
-            if (asset.getThumbnailObjectKey() != null) {
-                s3KeysToDelete.add(asset.getThumbnailObjectKey());
+            if (asset.getThumbnailObjectKey() != null && !asset.getThumbnailObjectKey().equals(asset.getObjectKey())) {
+                objectKeysToDelete.add(asset.getThumbnailObjectKey());
             }
         }
 
@@ -379,10 +379,10 @@ public class NoteServiceImpl implements NoteService {
                 .map(Asset::getId)
                 .collect(Collectors.toList());
 
-        // 5. S3 파일 삭제
-        if (!s3KeysToDelete.isEmpty()) {
-            s3Service.deleteFiles(s3KeysToDelete);
-            log.info("S3 파일 삭제 완료 - {} 개 파일", s3KeysToDelete.size());
+        // 5. GCS 파일 삭제
+        if (!objectKeysToDelete.isEmpty()) {
+            s3Service.deleteFiles(new ArrayList<>(objectKeysToDelete));
+            log.info("GCS 파일 삭제 완료 - {} 개 파일", objectKeysToDelete.size());
         }
 
         // 6. ChatMessage ID 목록 조회

--- a/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
+++ b/src/main/java/com/proovy/domain/note/service/NoteServiceImpl.java
@@ -365,12 +365,12 @@ public class NoteServiceImpl implements NoteService {
         long freedStorageBytes = 0L;
 
         for (Asset asset : assets) {
-            if (asset.getS3Key() != null) {
-                s3KeysToDelete.add(asset.getS3Key());
+            if (asset.getObjectKey() != null) {
+                s3KeysToDelete.add(asset.getObjectKey());
                 freedStorageBytes += asset.getFileSize();
             }
-            if (asset.getThumbnailS3Key() != null) {
-                s3KeysToDelete.add(asset.getThumbnailS3Key());
+            if (asset.getThumbnailObjectKey() != null) {
+                s3KeysToDelete.add(asset.getThumbnailObjectKey());
             }
         }
 
@@ -503,8 +503,8 @@ public class NoteServiceImpl implements NoteService {
         // 12. 자산 정보 DTO 생성
         List<NoteDetailResponse.AssetInfo> assetInfos = noteAssets.stream()
                 .map(asset -> {
-                    String thumbnailUrl = asset.getThumbnailS3Key() != null
-                            ? s3Service.getThumbnailUrl(asset.getThumbnailS3Key())
+                    String thumbnailUrl = asset.getThumbnailObjectKey() != null
+                            ? s3Service.getThumbnailUrl(asset.getThumbnailObjectKey())
                             : null;
                     FileCategory category = FileCategory.fromMimeType(asset.getMimeType());
 
@@ -672,7 +672,7 @@ public class NoteServiceImpl implements NoteService {
                             .fileId(asset.getId())
                             .fileName(asset.getFileName())
                             .fileType("SOLUTION")
-                            .downloadUrl(s3Service.getFileUrl(asset.getS3Key()))
+                            .downloadUrl(s3Service.getFileUrl(asset.getObjectKey()))
                             .build())
                     .collect(Collectors.toList());
             if (generatedFiles.isEmpty()) {
@@ -713,8 +713,8 @@ public class NoteServiceImpl implements NoteService {
         // 3. 자산 정보 DTO 생성
         List<AssetListResponse.AssetInfo> assetInfos = assets.stream()
                 .map(asset -> {
-                    String thumbnailUrl = asset.getThumbnailS3Key() != null
-                            ? s3Service.getThumbnailUrl(asset.getThumbnailS3Key())
+                    String thumbnailUrl = asset.getThumbnailObjectKey() != null
+                            ? s3Service.getThumbnailUrl(asset.getThumbnailObjectKey())
                             : null;
                     FileCategory category = FileCategory.fromMimeType(asset.getMimeType());
 

--- a/src/main/java/com/proovy/domain/storage/service/StorageService.java
+++ b/src/main/java/com/proovy/domain/storage/service/StorageService.java
@@ -22,7 +22,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -62,18 +64,18 @@ public class StorageService {
             throw new BusinessException(ErrorCode.STORAGE4031);
         }
 
-        // S3 키 수집 (원본 + 썸네일)
-        List<String> s3KeysToDelete = new ArrayList<>();
+        // GCS 키 수집 (원본 + 썸네일, 중복 제거)
+        Set<String> objectKeysToDelete = new HashSet<>();
         long totalFileSize = 0L;
 
         for (Asset asset : assets) {
             // 원본 파일
-            s3KeysToDelete.add(asset.getObjectKey());
+            objectKeysToDelete.add(asset.getObjectKey());
             totalFileSize += asset.getFileSize();
 
-            // 썸네일 파일
-            if (asset.getThumbnailObjectKey() != null) {
-                s3KeysToDelete.add(asset.getThumbnailObjectKey());
+            // 썸네일 파일 (원본과 다른 경우에만)
+            if (asset.getThumbnailObjectKey() != null && !asset.getThumbnailObjectKey().equals(asset.getObjectKey())) {
+                objectKeysToDelete.add(asset.getThumbnailObjectKey());
             }
         }
 
@@ -81,7 +83,7 @@ public class StorageService {
         assetRepository.deleteAllInBatch(assets);
 
         // S3에서 파일 삭제
-        s3Service.deleteFiles(s3KeysToDelete);
+        s3Service.deleteFiles(new ArrayList<>(objectKeysToDelete));
 
         // 스토리지 용량 반환 로깅
         log.info("[Storage] 사용자 {} - {} 개 파일 삭제, 용량 반환: {} bytes",

--- a/src/main/java/com/proovy/domain/storage/service/StorageService.java
+++ b/src/main/java/com/proovy/domain/storage/service/StorageService.java
@@ -68,12 +68,12 @@ public class StorageService {
 
         for (Asset asset : assets) {
             // 원본 파일
-            s3KeysToDelete.add(asset.getS3Key());
+            s3KeysToDelete.add(asset.getObjectKey());
             totalFileSize += asset.getFileSize();
 
             // 썸네일 파일
-            if (asset.getThumbnailS3Key() != null) {
-                s3KeysToDelete.add(asset.getThumbnailS3Key());
+            if (asset.getThumbnailObjectKey() != null) {
+                s3KeysToDelete.add(asset.getThumbnailObjectKey());
             }
         }
 
@@ -151,7 +151,7 @@ public class StorageService {
                             .filter(asset -> lowerKeyword == null || titleMatches ||
                                     asset.getFileName().toLowerCase().contains(lowerKeyword))
                             .map(asset -> {
-                                String thumbnailUrl = s3Service.getThumbnailUrl(asset.getThumbnailS3Key());
+                                String thumbnailUrl = s3Service.getThumbnailUrl(asset.getThumbnailObjectKey());
                                 return AssetSummaryDto.of(asset, thumbnailUrl);
                             })
                             .toList();

--- a/src/main/java/com/proovy/domain/user/service/UserService.java
+++ b/src/main/java/com/proovy/domain/user/service/UserService.java
@@ -205,14 +205,14 @@ public class UserService {
     }
 
     private void deleteUserData(Long userId) {
-        // S3 키를 먼저 수집 (원본 + 썸네일)
-        List<String> s3Keys = new java.util.ArrayList<>();
+        // GCS 키를 먼저 수집 (원본 + 썸네일)
+        List<String> objectKeys = new java.util.ArrayList<>();
         assetRepository.findAllByUserId(userId).forEach(asset -> {
-            if (asset.getS3Key() != null) {
-                s3Keys.add(asset.getS3Key());
+            if (asset.getObjectKey() != null) {
+                objectKeys.add(asset.getObjectKey());
             }
-            if (asset.getThumbnailS3Key() != null) {
-                s3Keys.add(asset.getThumbnailS3Key());
+            if (asset.getThumbnailObjectKey() != null) {
+                objectKeys.add(asset.getThumbnailObjectKey());
             }
         });
 
@@ -230,11 +230,11 @@ public class UserService {
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                s3Keys.forEach(key -> {
+                objectKeys.forEach(key -> {
                     try {
                         s3Service.deleteFile(key);
                     } catch (Exception e) {
-                        log.warn("S3 파일 삭제 실패: s3Key={}", key, e);
+                        log.warn("GCS 파일 삭제 실패: objectKey={}", key, e);
                     }
                 });
             }

--- a/src/main/java/com/proovy/domain/user/service/UserService.java
+++ b/src/main/java/com/proovy/domain/user/service/UserService.java
@@ -36,6 +36,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -205,13 +206,13 @@ public class UserService {
     }
 
     private void deleteUserData(Long userId) {
-        // GCS 키를 먼저 수집 (원본 + 썸네일)
-        List<String> objectKeys = new java.util.ArrayList<>();
+        // GCS 키를 먼저 수집 (원본 + 썸네일, 중복 제거)
+        Set<String> objectKeys = new java.util.HashSet<>();
         assetRepository.findAllByUserId(userId).forEach(asset -> {
             if (asset.getObjectKey() != null) {
                 objectKeys.add(asset.getObjectKey());
             }
-            if (asset.getThumbnailObjectKey() != null) {
+            if (asset.getThumbnailObjectKey() != null && !asset.getThumbnailObjectKey().equals(asset.getObjectKey())) {
                 objectKeys.add(asset.getThumbnailObjectKey());
             }
         });

--- a/src/main/resources/db/migration/V32__rename_s3_columns_to_object_keys.sql
+++ b/src/main/resources/db/migration/V32__rename_s3_columns_to_object_keys.sql
@@ -1,0 +1,3 @@
+-- V32: Rename S3 column names to generic object key names for GCS compatibility
+ALTER TABLE assets RENAME COLUMN s3_key TO object_key;
+ALTER TABLE assets RENAME COLUMN thumbnail_s3_key TO thumbnail_object_key;

--- a/src/test/java/com/proovy/domain/storage/service/StorageServiceTest.java
+++ b/src/test/java/com/proovy/domain/storage/service/StorageServiceTest.java
@@ -79,7 +79,7 @@ class StorageServiceTest {
                 .fileName("test.pdf")
                 .fileSize(1024L * 1024L * 100) // 100MB
                 .mimeType("application/pdf")
-                .s3Key("users/1/assets/test.pdf")
+                .objectKey("users/1/assets/test.pdf")
                 .source(Asset.AssetSource.upload)
                 .build();
         ReflectionTestUtils.setField(testAsset, "id", 1L);
@@ -217,7 +217,7 @@ class StorageServiceTest {
                     .fileName("file1.pdf")
                     .fileSize(1024L * 1024L * 200) // 200MB
                     .mimeType("application/pdf")
-                    .s3Key("key1")
+                    .objectKey("key1")
                     .source(Asset.AssetSource.upload)
                     .build();
             ReflectionTestUtils.setField(asset1, "id", 2L);
@@ -228,7 +228,7 @@ class StorageServiceTest {
                     .fileName("file2.png")
                     .fileSize(1024L * 1024L * 50) // 50MB
                     .mimeType("image/png")
-                    .s3Key("key2")
+                    .objectKey("key2")
                     .source(Asset.AssetSource.upload)
                     .build();
             ReflectionTestUtils.setField(asset2, "id", 3L);


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #209

🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

**S3 잔재 완전 제거 및 GCS 정합성 맞추기**  
AWS S3에서 GCP GCS로 마이그레이션 완료 후 남아있는 S3 잔재를 완전히 제거하고, DB 스키마와 엔티티간 정합성을 맞춰 prod 배포 시 Schema validation 오류를 해결했습니다.

**주요 변경사항:**
- V32 마이그레이션 추가: `s3_key` → `object_key`, `thumbnail_s3_key` → `thumbnail_object_key`
- Asset 엔티티 필드명 변경: `s3Key` → `objectKey`, `thumbnailS3Key` → `thumbnailObjectKey`
- DB 컬럼명과 엔티티 필드명 매핑을 위한 `@Column(name="...")` 추가
- 모든 서비스, DTO, 테스트 코드에서 새 필드명으로 업데이트

**수정된 파일들:**
- Asset.java - 엔티티 필드명 변경 및 컬럼 매핑 추가
- V32 마이그레이션 파일 생성 - DB 컬럼명 변경
- 11개 서비스 및 DTO 파일 - 필드 참조 업데이트

## 📸 스크린샷

빌드 성공 확인: `./gradlew clean build` 통과  
11개 파일 변경, 1개 마이그레이션 파일 생성  

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 컴파일 테스트를 통과했습니다
- [x] 관련 이슈와 연결했습니다
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 기존 Flyway 마이그레이션 파일(V0~V31) 절대 수정 금지 (체크섬 오류 방지)
- GCS 관련 코드/설정은 이미 정상 작동하므로 그대로 유지
- prod 프로파일의 `ddl-auto: validate`와 100% 호환되도록 수정
- 이제 prod 환경에서 Schema-validation 오류 없이 정상 부팅 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 에셋 관리, 대화, 사용자 서비스 전반에서 스토리지 키 명명 규칙을 업데이트했습니다.
  * 데이터베이스 스키마를 스토리지 키 용어 변경에 맞게 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-Proovy/Proovy-server/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->