### PR TITLE
[Fix] Upstash Redis TLS 연결 문제 해결

### DIFF
--- a/src/main/java/com/proovy/global/config/RedisConfig.java
+++ b/src/main/java/com/proovy/global/config/RedisConfig.java
@@ -42,7 +42,11 @@ public class RedisConfig {
         config.setPort(port);
         
         // 비밀번호 설정 (비어있지 않은 경우)
-        if (password != null && !password.trim().isEmpty()) {
+        if (sslEnabled && (password == null || password.isBlank())) {
+            throw new IllegalStateException("spring.data.redis.password must be set when SSL is enabled");
+        }
+
+        if (password != null && !password.isBlank()) {
             config.setPassword(password);
         }
 

--- a/src/main/java/com/proovy/global/config/RedisConfig.java
+++ b/src/main/java/com/proovy/global/config/RedisConfig.java
@@ -1,16 +1,23 @@
 package com.proovy.global.config;
 
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.SocketOptions;
+import io.lettuce.core.SslOptions;
+import io.lettuce.core.protocol.ProtocolVersion;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
 
 @Configuration
 @EnableRedisRepositories
@@ -22,13 +29,49 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
+    @Value("${spring.data.redis.password:}")
+    private String password;
+
+    @Value("${spring.data.redis.ssl.enabled:false}")
+    private boolean sslEnabled;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
         config.setHostName(host);
         config.setPort(port);
+        
+        // 비밀번호 설정 (비어있지 않은 경우)
+        if (password != null && !password.trim().isEmpty()) {
+            config.setPassword(password);
+        }
 
-        LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
+        LettuceClientConfiguration.LettuceClientConfigurationBuilder clientConfigBuilder = 
+                LettuceClientConfiguration.builder()
+                        .commandTimeout(Duration.ofMillis(5000));
+
+        // SSL 설정 (prod 환경에서 Upstash 호환)
+        if (sslEnabled) {
+            ClientOptions clientOptions = ClientOptions.builder()
+                    .protocolVersion(ProtocolVersion.RESP2)  // Upstash Redis 호환을 위해 RESP2 명시
+                    .sslOptions(SslOptions.builder()
+                            .jdkSslProvider()  // JDK SSL 프로바이더 사용
+                            .build())
+                    .socketOptions(SocketOptions.builder()
+                            .connectTimeout(Duration.ofSeconds(10))
+                            .keepAlive(true)  // Keep-alive 활성화
+                            .build())
+                    .autoReconnect(true)  // 자동 재연결 활성화
+                    .build();
+            
+            clientConfigBuilder
+                    .clientOptions(clientOptions)
+                    .useSsl()
+                    .and()
+                    .shutdownTimeout(Duration.ofMillis(100));
+        }
+
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(config, clientConfigBuilder.build());
         factory.setValidateConnection(true);
         return factory;
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -178,8 +178,6 @@ spring:
     redis:
       ssl:
         enabled: true
-        bundle:
-          implicit: true
 
 proovy:
   api:


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #211

🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

**Upstash Redis TLS 연결 실패 문제 해결**  
prod 환경에서 Upstash Redis 연결 시 `Connection closed prematurely at RedisHandshakeHandler` 오류 발생하던 문제를 해결했습니다.

**주요 수정사항:**
- RedisConfig에서 application.yaml의 SSL/비밀번호 설정을 제대로 읽도록 수정
- Upstash 호환을 위한 `ProtocolVersion.RESP2` 명시적 설정
- JDK SSL 프로바이더 사용 및 Keep-alive 활성화
- 자동 재연결 및 적절한 타임아웃 설정
- prod 프로파일의 `bundle.implicit: true` 설정 제거

**기술적 세부사항:**
- `LettuceClientConfiguration`으로 SSL 옵션 명시적 구성
- `ClientOptions`에 RESP2 프로토콜 버전 설정
- `SslOptions`에 JDK SSL 프로바이더 적용
- `SocketOptions`에 연결 타임아웃 및 Keep-alive 설정

## 📸 스크린샷

컴파일 성공 확인: `./gradlew compileJava` 통과  
2개 파일 수정: RedisConfig.java, application.yaml  

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 컴파일 테스트를 통과했습니다
- [x] 관련 이슈와 연결했습니다
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- local 프로파일 호환성 확인됨 (SSL 비활성화)
- 기존 Redis 사용처(AuthService, EmbeddingJobPublisher) 모두 정상 동작 예상
- Flyway 마이그레이션이나 기타 기능에는 영향 없음
- redis-cli로는 연결되지만 Lettuce만 실패하던 TLS handshake 문제 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Redis 데이터베이스 연결에 비밀번호 기반 인증 지원 추가
  * 프로덕션 환경에서 Redis 연결의 SSL 암호화 통신 활성화
  * 프로덕션 API 엔드포인트의 기본값 설정 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-Proovy/Proovy-server/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->